### PR TITLE
fix: align Home with canonical Advanced composition

### DIFF
--- a/.weaverse/specs/2026-08-05--advanced-visual-realignment/home-canonical-parity-handoff.md
+++ b/.weaverse/specs/2026-08-05--advanced-visual-realignment/home-canonical-parity-handoff.md
@@ -1,0 +1,106 @@
+# Home canonical parity correction
+
+Date: 2026-08-06
+Branch: `fix/home-canonical-parity`
+Base: merged `main@9f506d304e3d26e60156c4228a8acaa14d0fe0f9`
+
+## Why this correction exists
+
+Leo rejected the merged Home as visually completely different from the canonical Advanced POC. Prior route/runtime QA proved technical health but was incorrectly treated as visual evidence. This pass must match the canonical screenshot's page-level composition, not merely its palette or typography family.
+
+## Authoritative evidence
+
+Use these two user-captured desktop screenshots as the source of truth:
+
+- Current merged Preview: `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-user-evidence-2026-08-06/screencapture-forward-abhk47fol-hta218-vercel-app-2026-08-06-09_38_41.png`
+- Canonical Advanced POC: `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-user-evidence-2026-08-06/screencapture-weaverse-hydrogen-next-poc-vercel-app-theme-preview-advanced-index-html-2026-08-06-09_38_30.png`
+- Full side-by-side: `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-user-evidence-2026-08-06/full-page.jpg`
+- First fold: `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-user-evidence-2026-08-06/top-2100.jpg`
+- Vertical bands: the three `band-*.jpg` files in the same folder.
+
+The screenshots are both 2560px wide. The current page is 5247px tall; the canonical is 7389px tall. Do not chase height numerically with empty padding, but reproduce the canonical section scale, whitespace, image area, overlaps, and cadence that create that length.
+
+Canonical rendered URL: `https://weaverse-hydrogen-next-poc.vercel.app/theme-preview-advanced/index.html#/home`.
+
+## Blocking divergences to correct
+
+1. Hero: current uses a narrow 7/5 grid and a five-line inward headline. Canonical is an almost full-viewport editorial canvas with a much larger right image, left rail/body, and a two-line headline crossing the image on cream strips: `Move until` / `the map runs out.`
+2. Operating premise: current is a compressed single text block. Canonical is a large three-column composition with ghost `01`, `Carry less. / Notice more.`, body, metrics, link, and substantial vertical space.
+3. Field dossier: current collage is small. Canonical uses a large overlapping landscape + portrait/detail collage, circular altitude mark, acid edge, large quote, and generous whitespace.
+4. Equipment index: current is a uniform three-column catalog row using shared `ProductCard`. Canonical is a large asymmetric editorial field of differently sized/staggered plates. There are only three real products in Forward; use exactly those three normalized products and their real colorway images. Do not invent a fourth product. Build a Home-specific plate component and use primary/alternate/context imagery to reproduce the lifestyle/editorial rhythm.
+5. Dispatch: current is a shallow dark strip. Canonical is near viewport-height, with a dominant mountain image and a large dark editorial panel.
+6. Movement systems: current is a short equal row. Canonical has a large heading, generous whitespace, and three staggered cards with different dimensions and dark caption blocks.
+7. Footer: current is compressed. Canonical has a taller dark close, larger stacked wordmark, wider column geometry, more whitespace, and a substantial lower rail.
+
+## Allowed implementation scope
+
+Primary files:
+
+- `src/app/page.tsx`
+- `src/app/globals.css`
+- `src/components/site-footer.tsx`
+
+Only touch another presentation file if absolutely necessary and explain why in your final output.
+
+## Hard constraints
+
+- Do not edit `src/lib/**`, tests, scripts, public assets, package files, lockfile, configs, routes, cart logic, or credentials.
+- Pages/components must continue consuming normalized data only through `storefront`.
+- Do not import raw fixtures.
+- Keep all three real Forward products and collections; no fake fourth product.
+- Keep local approved media; no hotlinks and no new images.
+- Preserve semantic headings, links, alt text, keyboard access, reduced motion, and mobile no-overflow behavior.
+- Do not copy the POC source implementation; reproduce rendered composition from evidence.
+- Do not commit, push, deploy, open/update PRs, or modify the primary checkout/server.
+
+## Desktop acceptance
+
+At 2560px full-page capture, strict side-by-side review must show:
+
+- the same broad section sequence and dominant image/text proportions;
+- hero headline crossing the image, with comparable image dominance and first-fold height;
+- a large canonical-like operating premise grid;
+- a large overlapping field collage;
+- asymmetric editorial product plates rather than a uniform catalog row;
+- a near-viewport dark dispatch section;
+- spacious staggered movement cards;
+- a tall canonical-like footer;
+- page rhythm/length materially close to canonical for real compositional reasons.
+
+## Mobile acceptance
+
+At 390x844:
+
+- hero remains legible and art-directed without desktop overlap collisions;
+- every collage/plate stacks intentionally;
+- no horizontal overflow;
+- all links and controls remain usable;
+- images are not accidentally hidden or zero-height.
+
+## Pass 1 strict review — required corrections
+
+The first implementation pass materially aligned the macro sequence and page cadence, but it is not accepted yet. Correct these residual blockers without broadening scope:
+
+1. At 2560px the hero headline wraps as three lines (`Move until` / `the map` / `runs out.`). Canonical is exactly two lines (`Move until` / `the map runs out.`). Reduce desktop mega type or widen/reposition the second line so it stays one line while still crossing the image on a cream strip. Keep mobile wrapping intentional.
+2. Image roles are reversed. The canonical Field Dossier's dominant image is the hikers/trail image available from the normalized High Route collection. The canonical dark Dispatch dominant image is the mountain panorama available as `themeContent.standardBandImage`. Pass those normalized images into the correct sections; do not change fixtures or hardcode public paths.
+3. The dossier/equipment/movement editorial groups remain slightly too narrow at 2560. Increase only those Home canvas max widths modestly (for example from `max-w-7xl` toward a 90rem editorial canvas) while preserving intentional whitespace and mobile padding. Do not make all interior pages wider.
+4. The pass-1 footer overshoots canonical: the stacked wordmark is much too large and the footer is too tall. Reduce the stacked wordmark and desktop footer padding to sit between the original compressed footer and pass 1. Target approximately the canonical screenshot's wordmark/footer proportions.
+
+Pass-1 evidence:
+
+- `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-local-qa-2026-08-06/pass-1-vs-canonical-full.jpg`
+- `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-local-qa-2026-08-06/pass-1-vs-canonical-top.jpg`
+- `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-local-qa-2026-08-06/pass-1-vs-canonical-band-2.jpg`
+- `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-local-qa-2026-08-06/pass-1-vs-canonical-band-3.jpg`
+
+## Required worker verification
+
+Run focused checks only while editing:
+
+```bash
+bun run typecheck
+bun run lint
+bun run format:check
+```
+
+Hermes will run full build/tests/routes/browser/visual verification after the diff stabilizes.

--- a/.weaverse/specs/2026-08-05--advanced-visual-realignment/work-logs.md
+++ b/.weaverse/specs/2026-08-05--advanced-visual-realignment/work-logs.md
@@ -326,3 +326,35 @@ push/deploy; no credentials; no live auth/checkout/Shopify/Weaverse.
   uncommitted. Nothing was committed, pushed, merged, or opened as a PR pending
   Leo's visual review. Canonical primary `main` was left clean and its local
   server was restored on port 3333.
+
+## 2026-08-06 — screenshot-driven Home canonical parity correction
+
+- Leo rejected the merged Home as visually completely different from the canonical Advanced POC. This invalidates the prior final-verification statement that no blocker-level Home alignment defect remained. The technical and interaction results stayed valid, but they did not prove visual parity.
+- Locked Leo's exact 2560px-wide captures as authoritative evidence:
+  - merged Preview: `screencapture-forward-abhk47fol-hta218-vercel-app-2026-08-06-09_38_41.png` (`2560×5247`);
+  - canonical Advanced POC: `screencapture-weaverse-hydrogen-next-poc-vercel-app-theme-preview-advanced-index-html-2026-08-06-09_38_30.png` (`2560×7389`).
+  Durable copies and five side-by-side views live under `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-user-evidence-2026-08-06/`.
+- Created isolated branch/worktree `fix/home-canonical-parity` at merged `main@9f506d3`; primary `main` and its `3333` server remained unchanged.
+- Rebuilt `src/app/page.tsx` from the screenshot's macro composition rather than the previous token-level interpretation:
+  - two-line `Move until / the map runs out.` hero crossing a dominant image;
+  - three-column `Carry less. / Notice more.` operating premise;
+  - large hikers/tent overlap dossier with altitude mark;
+  - Home-specific asymmetric plates for the three real normalized products;
+  - near-viewport mountain dispatch split;
+  - staggered movement cards and a taller canonical-style footer.
+- Added Home-only display/plate utilities in `globals.css`; adjusted only the shared stacked footer wordmark/footer scale. No direct fixture imports and no changes under `src/lib`, tests, scripts, public assets, package/lock/config, routes, cart, Shopify, or Weaverse runtime.
+- Exact-width production-mode final Home capture is `2560×7888`; section sequence, dominant geometry, overlap, image roles, and dark/light cadence now materially follow the `2560×7389` canonical screenshot. The extra height is produced by the real three-product/editorial composition, not empty padding.
+- Remaining visual differences are explicit data/media contracts rather than hidden parity claims: Forward has three real products versus four POC placeholders, uses approved Forward product photography, and uses the normalized Camp Craft tent image instead of the POC campfire frame.
+- Final verification after all code edits:
+  - `bun run check` — green; 56/56 tests, 33 generated pages, 19 route patterns + 4 redirects;
+  - `bun run smoke:routes` — 30/30 HTTP checks;
+  - `bun audit --production` — no vulnerabilities;
+  - `git diff --check` — clean;
+  - production-mode Home interaction QA — three repeated Home/Shop navigation cycles, product deep-link, mobile menu, requested-image health, severe console logs, and desktop/mobile overflow all passed with `0 failures`;
+  - final visual/mobile evidence: `/Users/hta218/Documents/work/artifacts/forward-home-canonical-parity-local-qa-2026-08-06/`.
+- Copilot autoreview could not produce a report because CLI NDJSON session events triggered the documented parser-noise failure. The required fresh read-only Hermes fallback returned `BLOCK`: the first visual rewrite removed the Home product-card colorway radios, image swap, and selected-colorway deep links.
+- Fixed the accepted interaction blocker with `src/components/home-equipment-plate.tsx`, a Home-specific client plate that preserves the asymmetric composition while restoring named radio groups, pointer/keyboard selection, primary/context image swaps, and selected-colorway URLs. Native production Selenium verified Charcoal → Claystone by pointer, Claystone → Charcoal by keyboard, and both Ridge primary/context frames → Dune; href and checked-state assertions all passed.
+- The first focused post-fix review returned `BLOCK` on two accessibility details: the new swatch labels measured only `16×16`, and the selected state/name was not visible. The follow-up now mirrors the shared `ProductCard`: every label measures `44×44`, the selected swatch gets a visible carbon ring, and the row shows `activeColorway.name · NN colorways`. Production Selenium verified target sizes, settled selected/unselected border colors, visible active-name transitions, pointer/keyboard behavior, hrefs, and images with `0 failures`; evidence: `home-swatch-a11y-post-review-qa.json` in the local QA artifact folder.
+- Broad Home desktop/mobile QA remained `0 failures`. Accessible controls increased full-page height only from `7888` to `7907` desktop and from `9663` to `9721` mobile; section structure and canonical composition remain unchanged.
+- Final narrow read-only review returned `APPROVE`: no blocking findings; measured targets, selected state/name, pointer/keyboard behavior, href/image updates, hydration, console, overflow, and desktop/mobile QA all passed against the exact post-a11y diff.
+- Publication remained deferred until the final reviewer approval. User design approval remains pending before Shopify adapters, Weaverse sections/schemas, or production deployment.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,41 @@
   letter-spacing: -0.01em;
 }
 
+/*
+ * Home canvas scale. The Home page runs one step larger than the interior
+ * routes so its hero, section headings, and plate marks hold the canonical
+ * editorial proportions at desktop widths.
+ */
+@utility display-mega {
+  font-family: var(--font-display);
+  font-size: clamp(2.75rem, 6.4vw, 10rem);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+}
+
+@utility display-section {
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 3.9vw, 5.5rem);
+  line-height: 1;
+  letter-spacing: -0.015em;
+}
+
+/* Oversized ghost index number sitting behind/beside section copy. */
+@utility plate-ghost {
+  font-family: var(--font-display);
+  font-size: clamp(4.5rem, 9.5vw, 13rem);
+  line-height: 0.8;
+  letter-spacing: -0.03em;
+}
+
+/* Plate mark overlapping Home imagery — one step above `plate-number`. */
+@utility plate-mark {
+  font-family: var(--font-display);
+  font-size: clamp(2.75rem, 4.2vw, 6rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
 /* Giant serif plate/index numbers overlapping card imagery. */
 @utility plate-number {
   font-family: var(--font-display);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
-import { ProductCard } from "@/components/product-card";
+import { HomeEquipmentPlate } from "@/components/home-equipment-plate";
 import { cn } from "@/lib/cn";
 import { storefront } from "@/lib/storefront/data-source";
 import type {
@@ -18,35 +18,62 @@ export const metadata: Metadata = {
     "A short catalog of outdoor gear built for weather: shell, pack, and trail shoe. Built slowly, repaired indefinitely.",
 };
 
-/** Hero dossier: asymmetric grid, stepped oversized headline, telemetry rail. */
-function HeroDossier({
-  heroImage,
-  metrics,
-}: {
-  heroImage: StorefrontImage;
-  metrics: ReadonlyArray<{ value: string; label: string }>;
-}) {
+interface HomeMetric {
+  value: string;
+  label: string;
+}
+
+/** First sentence of a normalized description, used for card captions. */
+function firstSentence(text: string): string {
+  const end = text.indexOf(". ");
+  return end === -1 ? text : text.slice(0, end + 1);
+}
+
+/**
+ * Hero canvas: near-viewport editorial plate. The image dominates the right
+ * two thirds while the headline crosses it on a cream strip; the left rail
+ * carries the field-report marks.
+ */
+function HeroDossier({ heroImage }: { heroImage: StorefrontImage }) {
   return (
-    <section aria-label="Introduction" className="border-b border-carbon">
-      <div className="mx-auto grid max-w-7xl lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
-        <div className="flex flex-col justify-between gap-10 px-5 py-12 sm:px-8 lg:py-16">
-          <div>
+    <section
+      aria-label="Introduction"
+      className="relative overflow-hidden border-b border-carbon/15 bg-parchment"
+    >
+      <span
+        aria-hidden="true"
+        className="absolute left-7 top-28 hidden h-[28rem] w-px bg-carbon/25 lg:block"
+      />
+      <span
+        aria-hidden="true"
+        className="field-label absolute left-9 top-32 hidden origin-top-left rotate-90 text-slate/70 lg:block"
+      >
+        Forward — advanced field system
+      </span>
+      <div className="mx-auto max-w-[150rem] px-5 pb-16 pt-10 sm:px-8 lg:px-16 lg:pb-28 lg:pt-14">
+        <div className="lg:grid lg:grid-cols-12 lg:items-start">
+          <div className="relative z-10 lg:col-span-7 lg:col-start-1 lg:row-start-1 lg:min-w-0 lg:pt-20">
             <p className="field-label text-slate">
-              Forward / High country system · Est. 2026
+              Forward / High country system
             </p>
-            <h1 className="display-huge mt-6 text-carbon">
-              <span className="block">Gear for moving</span>
-              <span className="block pl-[0.08em] sm:pl-[1.5em]">
-                through weather,
+            <h1 className="display-mega mt-8 text-carbon lg:mt-10">
+              <span className="block">Move until</span>
+              {/*
+               * Desktop keeps the second line unbroken so it crosses the image
+               * as one cream strip; `min-w-0` on the column stops the nowrap
+               * line from widening the grid track. Mobile still wraps.
+               */}
+              <span className="mt-2 block lg:whitespace-nowrap lg:pl-[2.2em]">
+                <span className="box-decoration-clone bg-cream px-3 py-1">
+                  the map runs out.
+                </span>
               </span>
-              <span className="block italic text-pine">not around it.</span>
             </h1>
-            <p className="mt-8 max-w-sm text-base leading-relaxed text-slate">
-              Three products. A shell, a pack, and a trail shoe — built slowly,
-              specified honestly, and repaired for as long as you keep going
-              out.
+            <p className="mt-12 max-w-xs border-l border-carbon/30 pl-5 text-sm leading-relaxed text-slate lg:mt-20">
+              Purposeful layers and field equipment for uncertain weather,
+              useful distance, and the quiet beyond the marked route.
             </p>
-            <div className="mt-8 flex flex-wrap gap-3">
+            <div className="mt-8 flex flex-wrap items-center gap-6">
               <Link
                 href="/shop"
                 className="field-label inline-flex min-h-11 items-center bg-acid px-6 text-carbon transition-colors hover:bg-carbon hover:text-acid"
@@ -55,36 +82,34 @@ function HeroDossier({
               </Link>
               <Link
                 href="/pages/about-forward"
-                className="field-label inline-flex min-h-11 items-center border border-carbon px-6 text-carbon transition-colors hover:bg-carbon hover:text-cream"
+                className="field-label inline-flex min-h-11 items-center gap-2 text-carbon hover:text-clay"
               >
-                The field standard
+                The field standard →
               </Link>
             </div>
           </div>
-          <dl className="grid grid-cols-3 gap-6 border-t border-carbon/20 pt-6">
-            {metrics.map((metric) => (
-              <div key={metric.label}>
-                <dd className="font-display text-4xl leading-none text-carbon">
-                  {metric.value}
-                </dd>
-                <dt className="field-label mt-2 text-slate">{metric.label}</dt>
-              </div>
-            ))}
-          </dl>
-        </div>
-        <div className="relative border-t border-carbon lg:border-l lg:border-t-0">
-          <Image
-            src={heroImage.src}
-            alt={heroImage.alt}
-            width={heroImage.width}
-            height={heroImage.height}
-            priority
-            sizes="(min-width: 1024px) 42vw, 100vw"
-            className="h-full max-h-[34rem] w-full object-cover lg:max-h-none"
-          />
-          <div className="field-label absolute bottom-0 left-0 right-0 flex flex-wrap justify-between gap-x-6 gap-y-1 bg-carbon/85 px-4 py-3 text-cream/80">
-            <span>Conditions — variable, wind over the col</span>
-            <span>54.4609° N / 3.0886° W</span>
+          <div className="relative mt-10 lg:col-span-8 lg:col-start-5 lg:row-start-1 lg:mt-0">
+            <Image
+              src={heroImage.src}
+              alt={heroImage.alt}
+              width={heroImage.width}
+              height={heroImage.height}
+              priority
+              sizes="(min-width: 1024px) 66vw, 100vw"
+              className="aspect-4/3 w-full object-cover lg:aspect-7/5"
+            />
+            <dl className="field-label absolute bottom-0 right-0 hidden w-72 bg-carbon/90 px-4 py-3 text-cream/70 lg:block">
+              <dt className="sr-only">Current field conditions</dt>
+              <dd className="text-cream/90">Current field conditions</dd>
+              <dt className="sr-only">Wind</dt>
+              <dd className="mt-2 border-t border-cream/15 pt-2">
+                Wind — variable, over the col
+              </dd>
+              <dt className="sr-only">Position</dt>
+              <dd className="mt-2 border-t border-cream/15 pt-2">
+                54.4609° N / 3.0886° W
+              </dd>
+            </dl>
           </div>
         </div>
       </div>
@@ -92,150 +117,199 @@ function HeroDossier({
   );
 }
 
-/** Operating premise: ghost plate number, two-tone headline, field-standard link. */
-function OperatingPremise() {
+/** Operating premise: ghost plate number, three-column premise grid, metrics. */
+function OperatingPremise({ metrics }: { metrics: ReadonlyArray<HomeMetric> }) {
   return (
     <section
       aria-labelledby="premise-heading"
-      className="relative overflow-hidden border-b border-carbon/20"
+      className="border-b border-carbon/15"
     >
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute -top-8 right-2 font-display text-[10rem] leading-none text-carbon/10 sm:text-[16rem]"
-      >
-        01
-      </span>
-      <div className="mx-auto max-w-7xl px-5 py-16 sm:px-8">
-        <p className="field-label text-clay">Operating premise</p>
-        <h2 id="premise-heading" className="display-large mt-4 max-w-3xl">
-          <span className="text-carbon">Built to be worn out. </span>
-          <span className="italic text-pine">Made to be repaired.</span>
-        </h2>
-        <p className="mt-6 max-w-md text-base leading-relaxed text-slate">
-          Every product answers three questions before it ships: does it work
-          when the weather turns, does it carry its weight, and can we fix it
-          when you finally wear it out.
-        </p>
-        <Link
-          href="/pages/about-forward"
-          className="field-label mt-8 inline-flex min-h-11 items-center gap-2 border-b border-carbon text-carbon hover:text-clay"
-        >
-          Read the field standard →
-        </Link>
+      <div className="mx-auto max-w-7xl px-5 py-24 sm:px-8 lg:py-36">
+        <div className="grid gap-10 lg:grid-cols-12 lg:gap-10">
+          <span
+            aria-hidden="true"
+            className="plate-ghost block text-carbon/15 lg:col-span-2"
+          >
+            01
+          </span>
+          <div className="lg:col-span-5">
+            <p className="field-label text-slate">Operating premise</p>
+            <h2 id="premise-heading" className="display-section mt-5">
+              <span className="block text-carbon">Carry less.</span>
+              <span className="block text-moss">Notice more.</span>
+            </h2>
+          </div>
+          <div className="lg:col-span-5">
+            <p className="max-w-md text-base leading-relaxed text-slate">
+              We build adaptable outdoor goods around a strict premise: every
+              piece must earn its weight, survive a change of plan, and become
+              quieter with use.
+            </p>
+            <dl className="mt-12 grid grid-cols-3 gap-6 border-y border-carbon/20 py-7">
+              {metrics.map((metric) => (
+                <div key={metric.label}>
+                  <dd className="font-display text-4xl leading-none text-carbon lg:text-5xl">
+                    {metric.value}
+                  </dd>
+                  <dt className="field-label mt-3 text-slate">
+                    {metric.label}
+                  </dt>
+                </div>
+              ))}
+            </dl>
+            <Link
+              href="/pages/about-forward"
+              className="field-label mt-10 inline-flex min-h-11 items-center gap-2 border-b border-carbon text-carbon hover:text-clay"
+            >
+              Read the field standard →
+            </Link>
+          </div>
+        </div>
       </div>
     </section>
   );
 }
 
-/** Overlapping editorial dossier: stacked flow on mobile, offset planes on lg. */
+/**
+ * Field dossier: a large landscape plate with a circular altitude mark, an
+ * acid-edged detail plate overlapping it, and the pull quote below the overlap.
+ */
 function FieldDossier({
   primary,
   overlay,
-  detail,
 }: {
   primary: StorefrontImage;
   overlay: StorefrontImage;
-  detail: StorefrontImage;
 }) {
   return (
     <section
       aria-label="Field imagery"
-      className="border-b border-carbon/20 bg-parchment"
+      className="border-b border-carbon/15 bg-parchment"
     >
-      <div className="mx-auto grid max-w-7xl gap-10 px-5 py-16 sm:px-8 lg:grid-cols-12 lg:gap-0">
-        <div className="relative lg:col-span-8">
-          <Image
-            src={primary.src}
-            alt={primary.alt}
-            width={primary.width}
-            height={primary.height}
-            sizes="(min-width: 1024px) 60vw, 100vw"
-            className="aspect-4/3 w-full object-cover"
-          />
-          <p className="field-label mt-2 text-slate">
-            Traverse study / 02 · high route, late season
-          </p>
-          <div className="mt-6 lg:absolute lg:-right-24 lg:bottom-16 lg:mt-0 lg:w-72">
-            <div className="lg:bg-acid lg:p-2">
+      <div className="mx-auto max-w-[90rem] px-5 py-24 sm:px-8 lg:py-36">
+        <div className="grid gap-10 lg:grid-cols-12 lg:gap-0">
+          <div className="relative lg:col-span-7">
+            <Image
+              src={primary.src}
+              alt={primary.alt}
+              width={primary.width}
+              height={primary.height}
+              sizes="(min-width: 1024px) 58vw, 100vw"
+              className="aspect-4/3 w-full object-cover lg:aspect-9/8"
+            />
+            <span
+              aria-hidden="true"
+              className="absolute -right-14 top-12 hidden size-36 flex-col items-center justify-center rounded-full border border-carbon/40 bg-cream/85 text-center text-carbon lg:flex"
+            >
+              <span className="field-label text-slate">Field tested</span>
+              <span className="mt-1 font-display text-2xl leading-none">
+                4,000 ft
+              </span>
+            </span>
+            <p className="field-label mt-3 text-slate">
+              Traverse study / 03 · high route, late season
+            </p>
+          </div>
+          <div className="lg:col-span-5 lg:pt-44">
+            <div className="lg:-ml-32 lg:w-[27rem] lg:bg-acid lg:pb-3 lg:pl-3">
               <Image
                 src={overlay.src}
                 alt={overlay.alt}
                 width={overlay.width}
                 height={overlay.height}
-                sizes="(min-width: 1024px) 18rem, 100vw"
+                sizes="(min-width: 1024px) 27rem, 100vw"
                 className="aspect-4/3 w-full object-cover"
               />
             </div>
+            <p className="mt-8 max-w-sm font-display text-2xl leading-snug text-carbon lg:mt-12 lg:pl-6 lg:text-4xl">
+              A clothing system should disappear while moving and become exactly
+              enough when the weather turns.
+            </p>
           </div>
-          <span
-            aria-hidden="true"
-            className="field-label absolute left-4 top-4 hidden size-24 items-center justify-center rounded-full border border-cream/80 text-center text-cream lg:flex"
-          >
-            Field
-            <br />
-            tested
-          </span>
-        </div>
-        <div className="flex flex-col justify-end gap-8 lg:col-span-4 lg:pl-16">
-          <Image
-            src={detail.src}
-            alt={detail.alt}
-            width={detail.width}
-            height={detail.height}
-            sizes="(min-width: 1024px) 24vw, 100vw"
-            className="hidden aspect-3/4 w-2/3 object-cover lg:block"
-          />
-          <p className="max-w-xs font-display text-2xl leading-snug text-carbon">
-            A kit should disappear while moving and become exactly enough when
-            the weather turns.
-          </p>
         </div>
       </div>
     </section>
   );
 }
 
-/** Equipment index: staggered numbered product cards. */
+/** Equipment index: three real products staged as differently scaled plates. */
 function EquipmentIndex({ products }: { products: readonly Product[] }) {
+  const [lead, middle, trailing] = products;
+
   return (
     <section
       aria-labelledby="catalog-heading"
-      className="border-b border-carbon/20"
+      className="border-b border-carbon/15"
     >
-      <div className="mx-auto max-w-7xl px-5 py-16 sm:px-8">
+      <div className="mx-auto max-w-[90rem] px-5 py-24 sm:px-8 lg:py-36">
         <p className="field-label text-slate">
           Equipment index / 01–{String(products.length).padStart(2, "0")}
         </p>
-        <div className="mt-4 flex flex-wrap items-end justify-between gap-6">
-          <h2 id="catalog-heading" className="display-large max-w-2xl">
-            <span className="block text-carbon">The catalog,</span>
-            <span className="block italic text-pine">complete.</span>
+        <div className="mt-5 grid gap-8 lg:grid-cols-12 lg:items-end">
+          <h2 id="catalog-heading" className="display-section lg:col-span-6">
+            <span className="block text-carbon">Objects for</span>
+            <span className="block text-moss">going farther.</span>
           </h2>
-          <Link
-            href="/shop"
-            className="field-label inline-flex min-h-11 items-center gap-2 border border-carbon px-5 text-carbon transition-colors hover:bg-carbon hover:text-cream"
-          >
-            Complete index →
-          </Link>
+          <p className="field-label text-slate lg:col-span-3">
+            Three pieces, one system. Built to layer, carry, and repair.
+          </p>
+          <div className="lg:col-span-3 lg:text-right">
+            <Link
+              href="/shop"
+              className="field-label inline-flex min-h-11 items-center gap-2 border border-carbon px-5 text-carbon transition-colors hover:bg-carbon hover:text-cream"
+            >
+              Complete index →
+            </Link>
+          </div>
         </div>
-        <div className="mt-10 grid gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
-          {products.map((product, index) => (
-            <ProductCard
-              key={product.handle}
-              product={product}
-              plate={product.plate}
-              stagger={index % 3 === 1}
-              priority={index === 0}
+        <div className="mt-14 grid gap-x-8 gap-y-14 sm:grid-cols-2 lg:mt-24 lg:grid-cols-12 lg:items-start">
+          {lead !== undefined ? (
+            <HomeEquipmentPlate
+              product={lead}
+              tag={lead.activities[0] ?? "Field tested"}
+              aspect="aspect-3/4"
+              priority
+              className="lg:col-span-5"
             />
-          ))}
+          ) : null}
+          {middle !== undefined ? (
+            <HomeEquipmentPlate
+              product={middle}
+              tag={middle.activities[0] ?? "Field tested"}
+              aspect="aspect-4/5"
+              withContext
+              className="lg:col-span-3 lg:mt-28"
+            />
+          ) : null}
+          {trailing !== undefined ? (
+            <HomeEquipmentPlate
+              product={trailing}
+              tag={trailing.activities[0] ?? "Field tested"}
+              aspect="aspect-4/5"
+              className="lg:col-span-4 lg:mt-10"
+            />
+          ) : null}
         </div>
       </div>
     </section>
   );
 }
 
-/** Dark dispatch split from the lead journal article. */
-function DispatchSplit({ article }: { article: JournalArticle }) {
+/**
+ * Dark dispatch: near-viewport split of a dominant image and an editorial
+ * panel. The dominant frame is the wide mountain panorama band rather than the
+ * article's own trail frame, which the field dossier carries instead.
+ */
+function DispatchSplit({
+  article,
+  image,
+}: {
+  article: JournalArticle;
+  image: StorefrontImage;
+}) {
+  const [firstWord, ...restWords] = article.title.split(" ");
+  const note = article.body.find((block) => block.type === "paragraph");
+
   return (
     <section
       aria-labelledby="dispatch-heading"
@@ -244,38 +318,42 @@ function DispatchSplit({ article }: { article: JournalArticle }) {
     >
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute -bottom-10 right-0 font-display text-[12rem] leading-none text-cream/5 sm:text-[18rem]"
+        className="pointer-events-none absolute -bottom-16 right-4 font-display text-[14rem] leading-none text-cream/5 sm:text-[22rem]"
       >
         {article.plate.replace(/\D/g, "")}
       </span>
-      <div className="mx-auto grid max-w-7xl lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
-        <Image
-          src={article.heroImage.src}
-          alt={article.heroImage.alt}
-          width={article.heroImage.width}
-          height={article.heroImage.height}
-          sizes="(min-width: 1024px) 58vw, 100vw"
-          className="h-full max-h-[30rem] w-full object-cover lg:max-h-none"
-        />
-        <div className="relative flex flex-col justify-center gap-6 px-5 py-14 sm:px-8 lg:py-20">
+      <div className="grid lg:min-h-[85vh] lg:grid-cols-[minmax(0,62fr)_minmax(0,38fr)]">
+        <div className="relative aspect-4/3 lg:aspect-auto">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            sizes="(min-width: 1024px) 62vw, 100vw"
+            className="object-cover"
+          />
+          <p className="field-label absolute bottom-0 left-0 bg-acid px-3 py-2 text-carbon">
+            {article.location} · {article.readingMinutes} min read
+          </p>
+        </div>
+        <div className="relative flex flex-col justify-center gap-7 px-5 py-16 sm:px-8 lg:py-24 lg:pl-16 lg:pr-14">
           <p className="field-label text-clay-light">
             Dispatch {article.plate} / {article.location}
           </p>
-          <h2 id="dispatch-heading" className="display-large">
-            <span className="text-cream">{article.title.split(" ")[0]} </span>
-            <span className="italic text-acid">
-              {article.title.split(" ").slice(1).join(" ")}
-            </span>
+          <h2 id="dispatch-heading" className="display-section">
+            <span className="block text-cream">{firstWord}</span>
+            <span className="block text-acid">{restWords.join(" ")}</span>
           </h2>
-          <p className="max-w-sm font-display text-lg italic leading-relaxed text-cream/80">
+          <p className="max-w-md font-display text-xl italic leading-relaxed text-cream/90 lg:text-2xl">
             “{article.excerpt}”
           </p>
-          <p className="field-label text-cream/60">
-            Filed from {article.coordinates} · {article.readingMinutes} min read
-          </p>
+          {note !== undefined ? (
+            <p className="max-w-md text-sm leading-relaxed text-cream/60">
+              {note.text}
+            </p>
+          ) : null}
           <Link
             href={`/journal/${article.handle}`}
-            className="field-label inline-flex min-h-11 w-fit items-center border border-cream/60 px-6 text-cream transition-colors hover:bg-acid hover:border-acid hover:text-carbon"
+            className="field-label mt-2 inline-flex min-h-12 items-center justify-center border border-cream/50 px-6 text-cream transition-colors hover:border-acid hover:bg-acid hover:text-carbon"
           >
             Open dispatch {article.plate} →
           </Link>
@@ -285,21 +363,27 @@ function DispatchSplit({ article }: { article: JournalArticle }) {
   );
 }
 
-/** Movement systems: three staggered dark collection cards. */
+/** Movement systems: staggered collection plates over dark caption blocks. */
 function MovementSystems({
   collections,
 }: {
   collections: readonly Collection[];
 }) {
+  const layouts = [
+    { span: "lg:col-span-3 lg:mt-16", aspect: "aspect-3/4" },
+    { span: "lg:col-span-5", aspect: "aspect-4/5" },
+    { span: "lg:col-span-4 lg:mt-28", aspect: "aspect-square" },
+  ];
+
   return (
     <section aria-labelledby="movement-heading">
-      <div className="mx-auto max-w-7xl px-5 py-16 sm:px-8">
+      <div className="mx-auto max-w-[90rem] px-5 py-24 sm:px-8 lg:py-36">
         <p className="field-label text-slate">
           Movement systems / 01–{String(collections.length).padStart(2, "0")}
         </p>
-        <div className="mt-4 flex flex-wrap items-end justify-between gap-6">
-          <h2 id="movement-heading" className="display-large text-carbon">
-            Ways into the kit.
+        <div className="mt-5 flex flex-wrap items-end justify-between gap-6">
+          <h2 id="movement-heading" className="display-section text-carbon">
+            Choose your ground.
           </h2>
           <Link
             href="/shop"
@@ -308,42 +392,50 @@ function MovementSystems({
             All products →
           </Link>
         </div>
-        <div className="mt-10 grid gap-6 sm:grid-cols-3">
-          {collections.map((collection, index) => (
-            <Link
-              key={collection.handle}
-              href={`/shop/${collection.handle}`}
-              data-surface="dark"
-              className={cn(
-                "group relative block overflow-hidden bg-carbon text-cream",
-                index % 2 === 1 && "sm:mt-16",
-              )}
-            >
-              <Image
-                src={collection.heroImage.src}
-                alt={collection.heroImage.alt}
-                width={collection.heroImage.width}
-                height={collection.heroImage.height}
-                sizes="(min-width: 640px) 30vw, 100vw"
-                className="aspect-3/4 w-full object-cover opacity-75 transition-opacity group-hover:opacity-90"
-              />
-              <span
-                aria-hidden="true"
-                className="plate-number absolute left-4 top-4 text-cream"
+        <div className="mt-14 grid gap-8 sm:grid-cols-2 lg:mt-24 lg:grid-cols-12 lg:items-start">
+          {collections.map((collection, index) => {
+            const layout = layouts[index % layouts.length];
+            return (
+              <Link
+                key={collection.handle}
+                href={`/shop/${collection.handle}`}
+                data-surface="dark"
+                className={cn("group block", layout?.span)}
               >
-                {String(index + 1).padStart(2, "0")}
-              </span>
-              <span className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-carbon/90 to-transparent px-4 pb-4 pt-12">
-                <span className="block font-display text-2xl">
-                  {collection.title}
-                </span>
-                <span className="field-label mt-1 block text-cream/70">
-                  {collection.fieldCode} · {collection.productHandles.length}{" "}
-                  products
-                </span>
-              </span>
-            </Link>
-          ))}
+                <div className="relative">
+                  <Image
+                    src={collection.heroImage.src}
+                    alt={collection.heroImage.alt}
+                    width={collection.heroImage.width}
+                    height={collection.heroImage.height}
+                    sizes="(min-width: 1024px) 34vw, (min-width: 640px) 45vw, 90vw"
+                    className={cn(
+                      "w-full object-cover transition-opacity group-hover:opacity-90",
+                      layout?.aspect,
+                    )}
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="plate-mark absolute left-4 top-2 text-cream/90 [text-shadow:0_1px_12px_rgb(0_0_0/0.35)]"
+                  >
+                    {String(index + 1).padStart(2, "0")}
+                  </span>
+                </div>
+                <div className="bg-carbon px-5 pb-7 pt-5 text-cream">
+                  <span className="field-label block text-acid">
+                    {collection.fieldCode} · {collection.productHandles.length}{" "}
+                    products
+                  </span>
+                  <span className="mt-3 block font-display text-3xl leading-none lg:text-4xl">
+                    {collection.title}
+                  </span>
+                  <span className="mt-3 block text-sm leading-relaxed text-cream/65">
+                    {firstSentence(collection.description)}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
         </div>
       </div>
     </section>
@@ -362,7 +454,7 @@ export default async function HomePage() {
     (total, product) => total + product.colorways.length,
     0,
   );
-  const metrics = [
+  const metrics: readonly HomeMetric[] = [
     {
       value: String(products.length).padStart(2, "0"),
       label: "Catalog plates",
@@ -377,20 +469,20 @@ export default async function HomePage() {
     },
   ];
   const overlayImage = collections[2]?.heroImage ?? themeContent.homeHeroImage;
-  const detailImage = collections[1]?.heroImage ?? themeContent.homeHeroImage;
+  const dossierImage =
+    collections[1]?.heroImage ?? themeContent.standardBandImage;
 
   return (
     <div>
-      <HeroDossier heroImage={themeContent.homeHeroImage} metrics={metrics} />
-      <OperatingPremise />
-      <FieldDossier
-        primary={themeContent.standardBandImage}
-        overlay={overlayImage}
-        detail={detailImage}
-      />
+      <HeroDossier heroImage={themeContent.homeHeroImage} />
+      <OperatingPremise metrics={metrics} />
+      <FieldDossier primary={dossierImage} overlay={overlayImage} />
       <EquipmentIndex products={products} />
       {leadArticle !== undefined ? (
-        <DispatchSplit article={leadArticle} />
+        <DispatchSplit
+          article={leadArticle}
+          image={themeContent.standardBandImage}
+        />
       ) : null}
       <MovementSystems collections={collections} />
     </div>

--- a/src/components/home-equipment-plate.tsx
+++ b/src/components/home-equipment-plate.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useId, useState } from "react";
+
+import { cn } from "@/lib/cn";
+import { formatMoney } from "@/lib/storefront/format";
+import {
+  productColorwayHref,
+  resolveColorway,
+} from "@/lib/storefront/product-state";
+import type { Product } from "@/lib/storefront/types";
+
+interface HomeEquipmentPlateProps {
+  product: Product;
+  tag: string;
+  /** Aspect utility for the lead frame, e.g. `aspect-3/4`. */
+  aspect: string;
+  /** Stacks the colorway's in-the-field frame under the lead frame. */
+  withContext?: boolean;
+  priority?: boolean;
+  className?: string;
+}
+
+/**
+ * Home-only editorial product plate. Unlike the shared catalog card, plates
+ * carry their own scale and may stack a second in-the-field frame, so the
+ * index reads as an asymmetric field rather than a uniform row. Selecting a
+ * colorway swaps the primary/context images and retargets both product links,
+ * matching the shared ProductCard's selection semantics.
+ */
+export function HomeEquipmentPlate({
+  product,
+  tag,
+  aspect,
+  withContext,
+  priority,
+  className,
+}: HomeEquipmentPlateProps) {
+  const [activeColorwayId, setActiveColorwayId] = useState(
+    product.colorways[0]?.id ?? "",
+  );
+  const swatchGroupName = useId();
+  const activeColorway = resolveColorway(product, activeColorwayId);
+  const href = productColorwayHref(product, activeColorway.id);
+
+  return (
+    <article className={cn("group flex flex-col", className)}>
+      <Link href={href} className="relative block bg-parchment">
+        <Image
+          src={activeColorway.images.primary.src}
+          alt={activeColorway.images.primary.alt}
+          width={activeColorway.images.primary.width}
+          height={activeColorway.images.primary.height}
+          sizes="(min-width: 1024px) 34vw, (min-width: 640px) 45vw, 90vw"
+          priority={priority}
+          className={cn("w-full object-cover", aspect)}
+        />
+        <span
+          aria-hidden="true"
+          className="field-label absolute right-0 top-3 bg-acid px-2 py-1 text-carbon"
+        >
+          {tag}
+        </span>
+        {withContext ? (
+          <Image
+            src={activeColorway.images.context.src}
+            alt={activeColorway.images.context.alt}
+            width={activeColorway.images.context.width}
+            height={activeColorway.images.context.height}
+            sizes="(min-width: 1024px) 26vw, (min-width: 640px) 45vw, 90vw"
+            className="aspect-square w-full object-cover"
+          />
+        ) : null}
+        <span
+          aria-hidden="true"
+          className="plate-mark pointer-events-none absolute bottom-1 left-4 text-cream/90 [text-shadow:0_1px_12px_rgb(0_0_0/0.35)]"
+        >
+          {product.plate}
+        </span>
+      </Link>
+      <div className="flex items-baseline justify-between gap-4 pt-4">
+        <h3 className="font-display text-xl leading-tight text-carbon lg:text-2xl">
+          <Link href={href} className="hover:underline">
+            {product.title}
+          </Link>
+        </h3>
+        <p className="field-label text-carbon">{formatMoney(product.price)}</p>
+      </div>
+      <p className="field-label mt-2 text-slate">
+        {product.category} / {product.activities.join(" · ")}
+      </p>
+      <fieldset className="mt-1 flex min-w-0 items-center text-slate">
+        <legend className="sr-only">{product.title} colorway</legend>
+        {product.colorways.map((entry) => {
+          const selected = entry.id === activeColorway.id;
+          return (
+            <label
+              key={entry.id}
+              className="flex size-11 cursor-pointer items-center justify-center has-focus-visible:outline-2 has-focus-visible:outline-offset-2 has-focus-visible:outline-carbon"
+            >
+              <input
+                type="radio"
+                name={swatchGroupName}
+                value={entry.id}
+                checked={selected}
+                onChange={() => setActiveColorwayId(entry.id)}
+                className="sr-only"
+              />
+              <span className="sr-only">{entry.name} colorway</span>
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "flex size-5 items-center justify-center rounded-full border transition-colors",
+                  selected ? "border-carbon" : "border-transparent",
+                )}
+              >
+                <span
+                  className="block size-2.5 rounded-full border border-carbon/25"
+                  style={{ backgroundColor: entry.swatchColor }}
+                />
+              </span>
+            </label>
+          );
+        })}
+        <span className="field-label ml-auto text-right text-slate">
+          {activeColorway.name} ·{" "}
+          {String(product.colorways.length).padStart(2, "0")} colorways
+        </span>
+      </fieldset>
+    </article>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -11,21 +11,23 @@ export async function SiteFooter() {
 
   return (
     <footer data-surface="dark" className="bg-carbon-deep text-cream">
-      <div className="mx-auto grid max-w-7xl gap-12 px-5 py-16 sm:px-8 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
-        <div>
+      <div className="mx-auto grid max-w-7xl gap-14 px-5 py-20 sm:px-8 lg:grid-cols-[minmax(0,6fr)_minmax(0,6fr)] lg:gap-20 lg:py-28">
+        <div className="flex flex-col justify-between gap-12">
           <Wordmark size="stacked" />
-          <p className="mt-6 max-w-sm text-sm leading-relaxed text-cream/70">
-            {themeContent.footerTagline}
-          </p>
-          <p className="field-label mt-6 text-acid">
-            Field office · 54.4609° N, 3.0886° W
-          </p>
+          <div>
+            <p className="max-w-sm text-sm leading-relaxed text-cream/70">
+              {themeContent.footerTagline}
+            </p>
+            <p className="field-label mt-7 text-acid">
+              Field office · 54.4609° N, 3.0886° W
+            </p>
+          </div>
         </div>
-        <div className="grid gap-10 sm:grid-cols-3">
+        <div className="grid gap-10 sm:grid-cols-3 lg:gap-12 lg:pl-10 lg:pt-4">
           {navigation.footerColumns.map((column) => (
             <nav key={column.heading} aria-label={column.heading}>
               <h2 className="field-label text-cream/50">{column.heading}</h2>
-              <ul className="mt-4 space-y-1">
+              <ul className="mt-5 space-y-1">
                 {column.links.map((link) => (
                   <li key={link.href}>
                     <Link
@@ -42,7 +44,7 @@ export async function SiteFooter() {
         </div>
       </div>
       <div className="border-t border-cream/15">
-        <div className="field-label mx-auto flex max-w-7xl flex-wrap items-baseline justify-between gap-x-8 gap-y-2 px-5 py-5 text-cream/50 sm:px-8">
+        <div className="field-label mx-auto flex max-w-7xl flex-wrap items-baseline justify-between gap-x-8 gap-y-3 px-5 py-7 text-cream/50 sm:px-8">
           <p className="max-w-3xl normal-case tracking-normal">
             © 2026 Forward. {themeContent.demoNotice}
           </p>

--- a/src/components/wordmark.tsx
+++ b/src/components/wordmark.tsx
@@ -13,7 +13,7 @@ export function Wordmark({ size = "header" }: WordmarkProps) {
       <Link
         href="/"
         aria-label="Forward — home"
-        className="inline-block font-display font-semibold uppercase leading-[0.86] tracking-[-0.01em] text-[clamp(4.5rem,10vw,9rem)]"
+        className="inline-block font-display font-semibold uppercase leading-[0.84] tracking-[-0.015em] text-[clamp(4.5rem,8vw,8rem)]"
       >
         <span className="block">For</span>
         <span className="block">Ward</span>


### PR DESCRIPTION
Rebuild Home from the authoritative Advanced POC screenshot evidence while preserving the existing storefront substrate.

- Aligns the hero, premise, collage, equipment field, dispatch, movement, and footer composition.
- Restores accessible Home colorway selection with 44×44 targets, visible selected state, image swaps, and deep links.
- Passes `bun run check`, 30/30 route smoke, production audit, hosted desktop/mobile QA, and independent post-fix review.

Preview: https://forward-jnlqerjov-hta218.vercel.app (Vercel-protected; scoped review link delivered directly).
