### PR TITLE
Expand the premium storefront contract

### DIFF
--- a/scripts/smoke-routes.mts
+++ b/scripts/smoke-routes.mts
@@ -8,7 +8,6 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { connect, createServer } from "node:net";
 import path from "node:path";
@@ -19,7 +18,6 @@ import nextEnv from "@next/env";
 import {
   ACCOUNT_PROTOCOL_SMOKES,
   DYNAMIC_NOT_FOUND_SMOKES,
-  LIVE_CONTENT_SMOKE_FIXTURES,
   NOT_FOUND_SMOKE,
   PERMANENT_REDIRECT_STATUS,
   REDIRECT_CONTRACT,
@@ -63,25 +61,6 @@ if (accountValues.some(Boolean) && !accountValues.every(Boolean)) {
 }
 const CUSTOMER_ACCOUNT_MODE = accountValues.every(Boolean);
 
-function buildHasLiveContent(): boolean {
-  try {
-    const manifest = JSON.parse(
-      readFileSync(
-        path.join(process.cwd(), ".next", "prerender-manifest.json"),
-        "utf8",
-      ),
-    ) as { routes?: Record<string, unknown> };
-    return Object.hasOwn(
-      manifest.routes ?? {},
-      `/journal/${LIVE_CONTENT_SMOKE_FIXTURES.articleHandle}`,
-    );
-  } catch {
-    return false;
-  }
-}
-
-const LIVE_CONTENT_MODE = buildHasLiveContent();
-
 function modeAwareSmoke(route: (typeof ROUTE_CONTRACT)[number]): RouteSmoke {
   if (CUSTOMER_ACCOUNT_MODE && route.category === "account") {
     if (route.pattern === "/account/status") {
@@ -97,28 +76,7 @@ function modeAwareSmoke(route: (typeof ROUTE_CONTRACT)[number]): RouteSmoke {
       expectedContentType: "text/html",
     };
   }
-  if (!LIVE_CONTENT_MODE) {
-    return route.smoke;
-  }
-  switch (route.pattern) {
-    case "/journal/[articleHandle]":
-      return {
-        ...route.smoke,
-        path: `/journal/${LIVE_CONTENT_SMOKE_FIXTURES.articleHandle}`,
-      };
-    case "/pages/[pageHandle]":
-      return {
-        ...route.smoke,
-        path: `/pages/${LIVE_CONTENT_SMOKE_FIXTURES.pageHandle}`,
-      };
-    case "/policies/[policyHandle]":
-      return {
-        ...route.smoke,
-        path: `/policies/${LIVE_CONTENT_SMOKE_FIXTURES.policyHandle}`,
-      };
-    default:
-      return route.smoke;
-  }
+  return route.smoke;
 }
 
 function modeAwareAccountProtocolSmoke(smoke: RouteSmoke): RouteSmoke {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+import { ProductCard } from "@/components/product-card";
+import { storefront } from "@/lib/storefront/data-source";
+
+export const metadata: Metadata = {
+  title: "About Forward",
+  description: "The product principles and field standard behind Forward.",
+};
+
+export default async function AboutCustomPage() {
+  const [theme, products, collections] = await Promise.all([
+    storefront.getThemeContent(),
+    storefront.listProducts(),
+    storefront.listCollections(),
+  ]);
+  return (
+    <div className="custom-story-page">
+      <section className="custom-story-hero">
+        <div>
+          <p className="eyebrow">Custom page / About Forward</p>
+          <h1>Make less equipment. Make every piece matter.</h1>
+          <p className="lede">
+            Forward is built around complete movement systems rather than
+            seasonal noise: fewer products, clearer jobs, longer useful lives.
+          </p>
+        </div>
+        <Image
+          src={theme.homeHeroImage.src}
+          alt={theme.homeHeroImage.alt}
+          width={theme.homeHeroImage.width}
+          height={theme.homeHeroImage.height}
+          sizes="(min-width: 820px) 55vw, 100vw"
+          priority
+        />
+      </section>
+      <section className="custom-story-manifesto shell section">
+        <p className="eyebrow">The Forward standard</p>
+        <h2>Useful over novel. Repairable over disposable. Quiet over loud.</h2>
+        <div className="custom-story-columns">
+          <p>
+            We begin with the work a product must do, then remove anything that
+            does not improve movement, protection, carry, or recovery.
+          </p>
+          <p>
+            Materials are selected for known performance and honest aging. A
+            worn product should carry evidence of use—not become obsolete.
+          </p>
+          <p>
+            Every core object belongs to a system, so layers and equipment earn
+            their place together instead of competing for attention.
+          </p>
+        </div>
+      </section>
+      <section className="custom-story-stats">
+        <div>
+          <strong>{products.length}</strong>
+          <span className="custom-story-stat-label">core objects</span>
+        </div>
+        <div>
+          <strong>{collections.length - 1}</strong>
+          <span className="custom-story-stat-label">movement systems</span>
+        </div>
+        <div>
+          <strong>01</strong>
+          <span className="custom-story-stat-label">repair commitment</span>
+        </div>
+      </section>
+      <section className="section shell">
+        <header className="home-commerce-head">
+          <div>
+            <p className="eyebrow">Representative equipment</p>
+            <h2 className="h2">The standard, made physical.</h2>
+          </div>
+          <Link className="text-link" href="/shop">
+            Complete catalog
+          </Link>
+        </header>
+        <div className="product-grid">
+          {products.slice(0, 3).map((product) => (
+            <ProductCard key={product.handle} product={product} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -108,7 +108,7 @@ export default async function AccountPage({ searchParams }: AccountPageProps) {
             Anything bought from Forward can come back for repair — defects
             free, everything else at an honest quoted cost.
           </p>
-          <Link className="button" href="/pages/repairs">
+          <Link className="button" href="/pages/field-repair">
             The repairs programme
           </Link>
         </article>

--- a/src/app/canonical-source.css
+++ b/src/app/canonical-source.css
@@ -1891,9 +1891,9 @@ p {
   --orange-dark: #485c00;
   --white: #f5f1e8;
   --line: rgba(17, 19, 15, 0.22);
-  --display: var(--font-literata), Georgia, "Times New Roman", serif;
+  --display: var(--font-space-grotesk), "Helvetica Neue", sans-serif;
   --ui: var(--font-manrope), "Helvetica Neue", sans-serif;
-  --mono: var(--font-plex-mono), monospace;
+  --meta: var(--font-plex-mono), monospace;
   --max: 1540px;
   --pad: clamp(22px, 4.2vw, 72px);
   --header-h: 84px;
@@ -1920,7 +1920,7 @@ body {
 .breadcrumbs,
 .value-number,
 .code-404 {
-  font-family: var(--mono);
+  font-family: var(--meta);
   font-weight: 500;
   letter-spacing: 0.12em;
 }
@@ -1958,9 +1958,9 @@ body {
 .button {
   min-height: 50px;
   border-radius: 0;
-  font-family: var(--mono);
-  font-size: 10px;
-  font-weight: 500;
+  font-family: var(--ui);
+  font-size: 11px;
+  font-weight: 700;
 }
 .button-signal {
   background: var(--orange);
@@ -1977,7 +1977,7 @@ body {
   border-color: var(--ink);
 }
 .text-link {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 11px;
   font-weight: 500;
   text-transform: uppercase;
@@ -1990,7 +1990,7 @@ body {
   padding-inline: var(--pad);
   background: var(--orange);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   font-weight: 500;
 }
@@ -2012,7 +2012,7 @@ body {
   gap: 10px;
   padding-inline: 20px;
   border-inline-start-color: var(--line);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   font-weight: 500;
 }
@@ -2032,7 +2032,7 @@ body {
 }
 .header-actions .icon-button,
 .header-actions .header-link {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   font-weight: 500;
 }
@@ -2040,29 +2040,6 @@ body {
   color: var(--ink);
   background: var(--orange);
   border-radius: 50%;
-}
-.coordinate-spine {
-  position: fixed;
-  z-index: 79;
-  top: calc(30px + var(--header-h));
-  right: 0;
-  bottom: 0;
-  width: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  padding-block: 20px;
-  border-left: 1px solid rgba(245, 241, 232, 0.3);
-  background: var(--ink);
-  color: var(--white);
-  writing-mode: vertical-rl;
-  font-family: var(--mono);
-  font-size: 7px;
-  letter-spacing: 0.18em;
-}
-.coordinate-spine b {
-  color: var(--orange);
-  font-weight: 500;
 }
 .hero-advanced {
   min-height: max(810px, calc(100svh - 30px));
@@ -2104,7 +2081,7 @@ body {
   padding: 10px 12px;
   background: var(--orange);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -2122,7 +2099,7 @@ body {
   align-items: flex-start;
   padding-right: 16px;
   border-right: 1px solid var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 7px;
   letter-spacing: 0.12em;
   writing-mode: vertical-rl;
@@ -2198,7 +2175,7 @@ body {
   border: 1px solid rgba(245, 241, 232, 0.75);
   background: rgba(17, 19, 15, 0.86);
   color: var(--white);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
 }
@@ -2246,7 +2223,7 @@ body {
 }
 .manifesto-ledger span {
   padding: 15px 10px 15px 0;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
 }
@@ -2273,7 +2250,7 @@ body {
 }
 .image-dossier figcaption {
   margin-top: 8px;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
 }
@@ -2303,7 +2280,7 @@ body {
   border: 1px solid var(--ink);
   border-radius: 50%;
   transform: rotate(11deg);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 7px;
   text-transform: uppercase;
 }
@@ -2339,7 +2316,7 @@ body {
 }
 .runway-note {
   align-self: center;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   line-height: 1.8;
   text-transform: uppercase;
@@ -2359,24 +2336,13 @@ body {
 .product-card img {
   filter: saturate(0.76);
 }
-.product-number {
-  position: absolute;
-  z-index: 2;
-  left: 10px;
-  bottom: 8px;
-  color: var(--white);
-  font-family: var(--display);
-  font-size: clamp(48px, 6vw, 82px);
-  line-height: 0.8;
-  mix-blend-mode: difference;
-}
 .product-badge {
   top: 0;
   right: 0;
   left: auto;
   background: var(--orange);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   font-weight: 500;
 }
@@ -2386,36 +2352,18 @@ body {
 }
 .product-name {
   font-family: var(--display);
-  font-size: 18px;
-  font-weight: 400;
+  font-size: 19px;
+  font-weight: 600;
 }
 .product-detail {
-  font-family: var(--mono);
-  font-size: 8px;
+  font-family: var(--ui);
+  font-size: 9px;
+  font-weight: 600;
   text-transform: uppercase;
 }
 .product-runway {
-  grid-template-columns: 1.18fr 0.82fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: start;
-}
-.product-runway .product-card:first-child {
-  grid-row: span 2;
-}
-.product-runway .product-card:first-child img {
-  aspect-ratio: 3 / 4.7;
-}
-.product-runway .product-card:nth-child(2) {
-  margin-top: 120px;
-}
-.product-runway .product-card:nth-child(3) {
-  grid-row: span 2;
-}
-.product-runway .product-card:nth-child(3) img {
-  aspect-ratio: 3 / 4;
-}
-.product-runway .product-card:nth-child(4) {
-  grid-column: 2;
-  margin-top: -170px;
 }
 
 .dispatch-feature {
@@ -2442,7 +2390,7 @@ body {
   padding: 8px 10px;
   background: var(--orange);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
 }
@@ -2565,7 +2513,7 @@ body {
 .tool-button,
 .sort-select {
   border-color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
 }
 .plp-layout {
@@ -2573,31 +2521,18 @@ body {
   padding-top: 62px;
 }
 .plp-grid {
-  grid-template-columns: repeat(12, 1fr);
-  gap: 65px 14px;
-}
-.plp-grid .product-card {
-  grid-column: span 4;
-}
-.plp-grid .product-card:nth-child(5n + 1) {
-  grid-column: span 7;
-}
-.plp-grid .product-card:nth-child(5n + 2) {
-  grid-column: span 5;
-  margin-top: 110px;
-}
-.plp-grid .product-card:nth-child(5n + 1) img {
-  aspect-ratio: 5 / 4;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 56px 18px;
 }
 .filter-group summary,
 .option-label,
 .accordion-list summary {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   font-weight: 500;
 }
 .check-row {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
 }
 .check-row input {
@@ -2654,15 +2589,17 @@ body {
   box-shadow: 30px -30px 0 var(--orange);
 }
 .kit-list li {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
 }
 
 .pdp {
-  grid-template-columns: minmax(0, 1.4fr) minmax(420px, 0.6fr);
+  grid-template-columns: minmax(420px, 0.72fr) minmax(0, 1.28fr);
+  grid-template-areas: "details gallery";
   background: var(--ink);
 }
 .gallery {
+  grid-area: gallery;
   grid-template-columns: 1.25fr 0.75fr;
   gap: 10px;
   padding: 10px;
@@ -2682,11 +2619,13 @@ body {
 .gallery-button.active::after {
   background: var(--orange);
   color: var(--ink);
-  font-family: var(--mono);
+  font-family: var(--ui);
 }
 .product-panel {
+  grid-area: details;
   color: var(--white);
-  border-left-color: #484b43;
+  border-right: 1px solid #484b43;
+  border-left: 0;
 }
 .product-panel-inner {
   top: calc(var(--header-h) + 30px);
@@ -2708,7 +2647,7 @@ body {
 .option-chip {
   border-color: #65685f;
   color: var(--white);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
 }
 .option-chip:hover,
@@ -2800,7 +2739,7 @@ body {
   grid-template-columns: 190px 1fr;
 }
 .account-nav {
-  font-family: var(--mono);
+  font-family: var(--ui);
 }
 .account-nav a {
   font-size: 9px;
@@ -2983,7 +2922,7 @@ body {
 }
 .footer-col h2,
 .footer-bottom {
-  font-family: var(--mono);
+  font-family: var(--ui);
 }
 .footer-col a {
   font-size: 12px;
@@ -3053,7 +2992,7 @@ body {
   margin-left: auto;
   padding-left: 10px;
   color: var(--muted);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -3114,7 +3053,7 @@ a.check-row[aria-current] .check-dot {
   padding: 0 16px;
   list-style: none;
   cursor: pointer;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   font-weight: 500;
   letter-spacing: 0.1em;
@@ -3174,7 +3113,7 @@ a.check-row[aria-current] .check-dot {
   border-bottom: 0;
 }
 .spec-row dt {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -3210,7 +3149,7 @@ a.check-row[aria-current] .check-dot {
   margin: 18px 0 0;
   padding: 12px 14px;
   border-left: 2px solid var(--orange);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   line-height: 1.7;
   letter-spacing: 0.06em;
@@ -3247,24 +3186,14 @@ a.check-row[aria-current] .check-dot {
   .site-header {
     grid-template-columns: 1fr auto;
   }
-  .coordinate-spine {
-    display: none;
-  }
   .product-runway {
     grid-template-columns: 1fr 1fr;
   }
-  .product-runway .product-card:nth-child(n) {
-    grid-column: auto;
-    grid-row: auto;
-    margin-top: 0;
-  }
-  .plp-grid .product-card,
-  .plp-grid .product-card:nth-child(n) {
-    grid-column: span 6;
-    margin-top: 0;
+  .plp-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .pdp {
-    grid-template-columns: 1.08fr 0.92fr;
+    grid-template-columns: minmax(360px, 0.88fr) minmax(0, 1.12fr);
   }
   .manifesto {
     grid-template-columns: 80px 1fr;
@@ -3421,8 +3350,10 @@ a.check-row[aria-current] .check-dot {
   }
   .pdp {
     grid-template-columns: 1fr;
+    grid-template-areas: "gallery" "details";
   }
   .product-panel {
+    border-right: 0;
     border-top: 1px solid #4a4d45;
   }
   .product-panel-inner {
@@ -3556,12 +3487,7 @@ a.check-row[aria-current] .check-dot {
     grid-template-columns: 1fr 1fr;
     gap: 10px;
   }
-  .product-runway .product-card:nth-child(n) {
-    grid-column: auto;
-  }
-  .product-number {
-    font-size: 44px;
-  }
+
   .product-name {
     font-size: 15px;
   }
@@ -3589,10 +3515,7 @@ a.check-row[aria-current] .check-dot {
     grid-template-columns: 1fr 1fr;
     gap: 35px 10px;
   }
-  .plp-grid .product-card,
-  .plp-grid .product-card:nth-child(n) {
-    grid-column: auto;
-  }
+
   .gallery-button:first-child img {
     min-height: 0;
     aspect-ratio: 4 / 5;
@@ -3637,6 +3560,43 @@ a.check-row[aria-current] .check-dot {
 @media (max-width: 820px) {
   .filter-disclosure {
     display: block;
+  }
+
+  /* Mobile cascade guard: these rules intentionally follow the advanced
+   * desktop overrides above so narrow layouts cannot retain desktop geometry. */
+  .hero-advanced .hero-content {
+    min-width: 0;
+    overflow: hidden;
+  }
+  .hero-advanced .hero-sub {
+    box-sizing: border-box;
+    min-width: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+  .page-hero-inner {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 28px;
+  }
+  .page-hero .lede {
+    max-width: 100%;
+    justify-self: start;
+  }
+  .gallery {
+    width: 100%;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .gallery-button:first-child {
+    grid-column: 1;
+    grid-row: auto;
+  }
+  .gallery-button img,
+  .gallery-button:first-child img {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+    aspect-ratio: 4 / 5;
   }
 }
 

--- a/src/app/canonical-source.css
+++ b/src/app/canonical-source.css
@@ -945,6 +945,11 @@ p {
   background: var(--forest);
   color: var(--white);
 }
+.option-chip.unavailable {
+  cursor: not-allowed;
+  text-decoration: line-through;
+  opacity: 0.48;
+}
 .product-actions {
   display: grid;
   grid-template-columns: 112px 1fr;
@@ -1891,7 +1896,7 @@ p {
   --orange-dark: #485c00;
   --white: #f5f1e8;
   --line: rgba(17, 19, 15, 0.22);
-  --display: var(--font-space-grotesk), "Helvetica Neue", sans-serif;
+  --display: var(--font-archivo), sans-serif;
   --ui: var(--font-manrope), "Helvetica Neue", sans-serif;
   --meta: var(--font-plex-mono), monospace;
   --max: 1540px;
@@ -3597,6 +3602,747 @@ a.check-row[aria-current] .check-dot {
     height: auto;
     min-height: 0;
     aspect-ratio: 4 / 5;
+  }
+}
+
+/* Commerce-first Home, custom compositions, and PDP image viewer. This late
+ * feature slice intentionally owns only new class names plus explicit PDP states. */
+.commerce-home {
+  background: var(--white);
+}
+.commerce-hero {
+  min-height: calc(100svh - var(--header-h));
+  display: grid;
+  grid-template-columns: minmax(390px, 0.78fr) minmax(0, 1.22fr);
+  background: var(--ink);
+  color: var(--white);
+}
+.commerce-hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(48px, 6vw, 100px);
+}
+.commerce-hero .display {
+  max-width: 760px;
+  margin: 22px 0 28px;
+  font-size: clamp(58px, 6.7vw, 112px);
+  line-height: 0.88;
+  letter-spacing: -0.065em;
+}
+.commerce-hero .lede {
+  max-width: 570px;
+  color: #c5c8be;
+}
+.commerce-hero-actions,
+.home-proof-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-top: 34px;
+}
+.commerce-hero-facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: auto 0 0;
+  padding-top: 36px;
+  border-top: 1px solid #474b43;
+}
+.commerce-hero-facts div {
+  display: grid;
+  gap: 6px;
+}
+.commerce-hero-facts dt,
+.commerce-hero-facts dd {
+  margin: 0;
+}
+.commerce-hero-facts dt {
+  color: #9ea298;
+  font-family: var(--meta);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.commerce-hero-facts dd {
+  font-family: var(--display);
+  font-size: 27px;
+}
+.commerce-hero-media {
+  position: relative;
+  min-height: 760px;
+  margin: 20px;
+  overflow: hidden;
+}
+.commerce-hero-media > img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.78) contrast(1.05);
+}
+.commerce-hero-product {
+  position: absolute;
+  right: 18px;
+  bottom: 18px;
+  width: min(330px, calc(100% - 36px));
+  display: grid;
+  gap: 8px;
+  padding: 20px;
+  background: var(--orange);
+  color: var(--ink);
+}
+.commerce-hero-product-meta {
+  font-family: var(--meta);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.commerce-hero-product strong {
+  font-family: var(--display);
+  font-size: 25px;
+}
+.home-commerce-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.42fr) auto;
+  align-items: end;
+  gap: 40px;
+  margin-bottom: 45px;
+}
+.home-commerce-head p {
+  max-width: 460px;
+  margin: 0;
+}
+.home-featured-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.home-system-section {
+  padding: 80px 0 0;
+  background: var(--ink);
+  color: var(--white);
+}
+.home-system-intro {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  padding-bottom: 44px;
+}
+.home-system-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.home-system-card {
+  position: relative;
+  min-height: 710px;
+  overflow: hidden;
+  border-right: 1px solid #52554e;
+  color: var(--white);
+}
+.home-system-card::after {
+  content: "";
+  position: absolute;
+  inset: 40% 0 0;
+  background: linear-gradient(transparent, rgba(5, 8, 6, 0.94));
+}
+.home-system-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.72);
+  transition: transform 0.5s ease;
+}
+.home-system-card:hover img {
+  transform: scale(1.025);
+}
+.home-system-card > div {
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 34px;
+}
+.home-system-card h3 {
+  margin: 8px 0 16px;
+  font-family: var(--display);
+  font-size: clamp(42px, 4vw, 68px);
+  line-height: 0.95;
+}
+.home-system-card p {
+  max-width: 420px;
+  color: #c5c8be;
+}
+.home-system-card > div > span:last-child {
+  display: block;
+  margin-top: 24px;
+  font-family: var(--ui);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+.home-spotlight {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(380px, 0.75fr);
+  gap: 0;
+}
+.home-spotlight-media img {
+  width: 100%;
+  height: 100%;
+  min-height: 760px;
+  object-fit: cover;
+}
+.home-spotlight-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(42px, 6vw, 92px);
+  background: var(--sand);
+}
+.home-spotlight-copy ul {
+  margin: 30px 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+.home-spotlight-copy li {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 12px;
+}
+.home-spotlight-copy .button {
+  align-self: flex-start;
+}
+.home-proof-band {
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  background: var(--ink);
+  color: var(--white);
+}
+.home-proof-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(48px, 7vw, 110px);
+}
+.home-proof-copy > p:not(.eyebrow) {
+  max-width: 560px;
+  color: #c5c8be;
+  font-size: 18px;
+}
+.home-proof-band > img {
+  width: 100%;
+  height: 700px;
+  object-fit: cover;
+  filter: saturate(0.7);
+}
+.home-kit {
+  display: grid;
+  grid-template-columns: 0.55fr 1.45fr;
+  gap: 60px;
+  align-items: end;
+}
+.home-kit-copy {
+  padding-bottom: 30px;
+}
+.home-kit-products {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.home-kit-products img {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+}
+.home-kit-product-name {
+  display: block;
+  margin-top: 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.home-service-grid {
+  display: grid;
+  grid-template-columns: 0.7fr 1.3fr;
+  gap: 12px;
+}
+.home-service-grid > article {
+  min-height: 560px;
+  padding: clamp(35px, 5vw, 70px);
+  background: var(--orange);
+}
+.home-service-grid h2 {
+  font-family: var(--display);
+  font-size: clamp(44px, 5vw, 78px);
+  line-height: 0.95;
+}
+.home-service-grid > .home-dispatch-card {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  padding: 0;
+  background: var(--sand);
+}
+.home-dispatch-card > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.home-dispatch-card > div {
+  align-self: center;
+  padding: 45px;
+}
+.custom-story-hero {
+  min-height: 82svh;
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  margin: 22px 28px 0;
+  background: var(--ink);
+  color: var(--white);
+}
+.custom-story-hero > div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(45px, 6vw, 95px);
+}
+.custom-story-hero h1,
+.testing-hero h1 {
+  margin: 20px 0 30px;
+  font-family: var(--display);
+  font-size: clamp(58px, 7vw, 112px);
+  line-height: 0.9;
+  letter-spacing: -0.06em;
+}
+.custom-story-hero img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.72);
+}
+.custom-story-hero-reverse > div {
+  order: 2;
+}
+.custom-story-hero-reverse > img {
+  order: 1;
+}
+.custom-story-manifesto > h2 {
+  max-width: 1100px;
+  font-family: var(--display);
+  font-size: clamp(48px, 7vw, 100px);
+  line-height: 0.95;
+}
+.custom-story-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px;
+  margin-top: 70px;
+  font-size: 18px;
+}
+.custom-story-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background: var(--orange);
+}
+.custom-story-stats div {
+  display: grid;
+  gap: 4px;
+  padding: 55px;
+  border-right: 1px solid var(--ink);
+}
+.custom-story-stats strong {
+  font-family: var(--display);
+  font-size: 72px;
+}
+.custom-story-stat-label {
+  font-family: var(--meta);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.material-principles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--ink);
+  padding: 1px;
+}
+.material-principles article {
+  min-height: 420px;
+  padding: 45px;
+  background: var(--white);
+}
+.material-principle-number {
+  color: var(--orange-dark);
+  font-family: var(--meta);
+}
+.material-principles h2 {
+  margin-top: 80px;
+  font-family: var(--display);
+  font-size: 38px;
+}
+.material-product-band {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  background: var(--ink);
+}
+.material-product-band a {
+  position: relative;
+  min-height: 650px;
+  color: var(--white);
+}
+.material-product-band img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.65);
+}
+.material-product-band a > div {
+  position: absolute;
+  right: 20px;
+  bottom: 20px;
+  left: 20px;
+  display: grid;
+  gap: 7px;
+  padding: 20px;
+  background: rgba(17, 19, 15, 0.92);
+}
+.custom-story-cta {
+  display: grid;
+  grid-template-columns: 1fr 0.7fr auto;
+  align-items: end;
+  gap: 45px;
+}
+.testing-hero {
+  position: relative;
+  min-height: 90svh;
+  margin: 22px 28px 0;
+  overflow: hidden;
+  color: var(--white);
+}
+.testing-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(10, 12, 9, 0.9),
+    rgba(10, 12, 9, 0.08)
+  );
+}
+.testing-hero > img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.testing-hero > div {
+  position: relative;
+  z-index: 1;
+  max-width: 820px;
+  padding: clamp(70px, 9vw, 150px);
+}
+.testing-hero > div > p:last-child {
+  max-width: 560px;
+  font-size: 20px;
+}
+.testing-sequence {
+  display: grid;
+  grid-template-columns: 0.7fr 1.3fr;
+  gap: 80px;
+}
+.testing-sequence ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--line);
+}
+.testing-sequence li {
+  display: grid;
+  grid-template-columns: 65px 1fr;
+  gap: 20px;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--line);
+}
+.testing-sequence-number {
+  font-family: var(--meta);
+}
+.testing-sequence h3 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 30px;
+}
+.testing-product {
+  display: grid;
+  grid-template-columns: 0.75fr 1.25fr;
+  background: var(--ink);
+  color: var(--white);
+}
+.testing-product > div {
+  align-self: center;
+  padding: clamp(50px, 7vw, 110px);
+}
+.testing-product h2 {
+  font-family: var(--display);
+  font-size: clamp(50px, 6vw, 94px);
+  line-height: 0.92;
+}
+.testing-product dl {
+  margin: 35px 0;
+  border-top: 1px solid #4a4d45;
+}
+.testing-product dl div {
+  display: flex;
+  justify-content: space-between;
+  padding: 13px 0;
+  border-bottom: 1px solid #4a4d45;
+}
+.testing-product img {
+  width: 100%;
+  height: 760px;
+  object-fit: cover;
+}
+.gallery-button:nth-child(n + 4) {
+  grid-column: 1 / -1;
+}
+.gallery-button:nth-child(n + 4) img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 10;
+}
+.gallery-zoom-label {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  padding: 7px 10px;
+  background: rgba(17, 19, 15, 0.88);
+  color: var(--white);
+  font-family: var(--ui);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.gallery-modal {
+  width: 100vw;
+  max-width: none;
+  height: 100svh;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: var(--ink);
+  color: var(--white);
+}
+.gallery-modal::backdrop {
+  background: rgba(0, 0, 0, 0.94);
+}
+.gallery-modal-bar {
+  height: 58px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 30px;
+  padding: 0 20px;
+  border-bottom: 1px solid #4a4d45;
+  font-family: var(--meta);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.gallery-modal-bar button {
+  min-height: 44px;
+  padding-inline: 16px;
+  background: var(--orange);
+  color: var(--ink);
+}
+.gallery-modal-stage {
+  position: relative;
+  height: calc(100svh - 148px);
+  display: grid;
+  place-items: center;
+  padding: 18px 80px;
+}
+.gallery-modal-stage img {
+  width: auto;
+  height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+.gallery-modal-arrow {
+  position: absolute;
+  top: 50%;
+  width: 48px;
+  height: 56px;
+  background: var(--orange);
+  color: var(--ink);
+  font-size: 24px;
+}
+.gallery-modal-prev {
+  left: 16px;
+}
+.gallery-modal-next {
+  right: 16px;
+}
+.gallery-modal-thumbs {
+  height: 90px;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px;
+  border-top: 1px solid #4a4d45;
+}
+.gallery-modal-thumbs button {
+  width: 56px;
+  padding: 0;
+  opacity: 0.55;
+  border: 1px solid transparent;
+}
+.gallery-modal-thumbs button.active {
+  opacity: 1;
+  border-color: var(--orange);
+}
+.gallery-modal-thumbs img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.product-panel .product-atc {
+  background: var(--orange);
+  border-color: var(--orange);
+  color: var(--ink);
+}
+.product-panel .product-atc:hover,
+.product-panel .product-atc:focus-visible {
+  background: var(--white);
+  border-color: var(--white);
+  color: var(--ink);
+  outline: 2px solid var(--orange);
+  outline-offset: 3px;
+}
+.product-panel .product-atc:disabled {
+  background: #53564f;
+  border-color: #53564f;
+  color: #b9bcb4;
+}
+
+@media (max-width: 820px) {
+  .commerce-hero,
+  .home-spotlight,
+  .home-proof-band,
+  .home-kit,
+  .home-service-grid,
+  .home-service-grid > .home-dispatch-card,
+  .custom-story-hero,
+  .custom-story-cta,
+  .testing-sequence,
+  .testing-product {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .commerce-hero-copy {
+    padding: 55px var(--pad);
+  }
+  .commerce-hero .display {
+    font-size: clamp(52px, 16vw, 78px);
+  }
+  .commerce-hero-media {
+    min-height: 68svh;
+    margin: 0 10px 10px;
+  }
+  .commerce-hero-facts {
+    margin-top: 45px;
+  }
+  .home-commerce-head {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+  .home-featured-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .home-system-grid,
+  .custom-story-columns,
+  .custom-story-stats,
+  .material-principles,
+  .material-product-band {
+    grid-template-columns: 1fr;
+  }
+  .home-system-card {
+    min-height: 600px;
+  }
+  .home-spotlight-media img {
+    min-height: 0;
+    aspect-ratio: 4 / 5;
+  }
+  .home-proof-band > img {
+    height: 58svh;
+  }
+  .home-kit-products {
+    gap: 7px;
+  }
+  .home-service-grid > article {
+    min-height: 0;
+  }
+  .home-dispatch-card > img {
+    max-height: 55svh;
+  }
+  .custom-story-hero,
+  .testing-hero {
+    min-height: 0;
+    margin: 10px 10px 0;
+  }
+  .custom-story-hero > div {
+    padding: 55px var(--pad);
+  }
+  .custom-story-hero img {
+    height: 60svh;
+  }
+  .custom-story-hero-reverse > div {
+    order: 1;
+  }
+  .custom-story-hero-reverse > img {
+    order: 2;
+  }
+  .custom-story-hero h1,
+  .testing-hero h1 {
+    font-size: clamp(50px, 15vw, 76px);
+  }
+  .custom-story-columns {
+    gap: 10px;
+    margin-top: 35px;
+  }
+  .custom-story-stats div {
+    padding: 34px var(--pad);
+    border-bottom: 1px solid var(--ink);
+  }
+  .material-principles article {
+    min-height: 0;
+  }
+  .material-principles h2 {
+    margin-top: 35px;
+  }
+  .material-product-band a {
+    min-height: 600px;
+  }
+  .testing-hero > div {
+    padding: 65px var(--pad);
+  }
+  .testing-product > div {
+    order: 2;
+  }
+  .testing-product img {
+    height: 62svh;
+  }
+  .gallery-button:nth-child(n + 4) img {
+    aspect-ratio: 4 / 5;
+  }
+  .gallery-modal-bar {
+    grid-template-columns: 1fr auto;
+  }
+  .gallery-modal-bar > span:nth-child(2) {
+    display: none;
+  }
+  .gallery-modal-stage {
+    height: calc(100svh - 138px);
+    padding: 12px 50px;
+  }
+  .gallery-modal-thumbs {
+    height: 80px;
   }
 }
 

--- a/src/app/canonical-source.css
+++ b/src/app/canonical-source.css
@@ -449,46 +449,6 @@ p {
   cursor: not-allowed;
 }
 
-.hero {
-  min-height: calc(100svh - var(--header-h) - 32px);
-  position: relative;
-  display: flex;
-  align-items: end;
-  padding: clamp(46px, 8vw, 116px) var(--pad);
-  overflow: hidden;
-  color: var(--white);
-  background: var(--forest-deep);
-}
-.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(6, 18, 13, 0.43);
-  z-index: 1;
-}
-.hero-image {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-.hero-content {
-  position: relative;
-  z-index: 2;
-  width: min(920px, 90%);
-}
-.hero .eyebrow {
-  color: #ff9b77;
-}
-.hero .display {
-  max-width: 900px;
-}
-.hero-sub {
-  max-width: 520px;
-  margin: 28px 0 32px;
-  font-size: 18px;
-}
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -582,67 +542,6 @@ p {
 .field-notes {
   background: var(--forest);
   color: var(--white);
-}
-.field-copy {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: clamp(48px, 8vw, 120px);
-}
-.field-copy .eyebrow {
-  color: #ff9b77;
-}
-.field-copy .h2 {
-  max-width: 660px;
-}
-.field-copy p:not(.eyebrow) {
-  max-width: 560px;
-  margin: 28px 0 36px;
-  color: #dce4dc;
-  font-size: 17px;
-}
-
-.activity-strip {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-}
-.activity-tile {
-  min-height: 500px;
-  position: relative;
-  overflow: hidden;
-  display: flex;
-  align-items: end;
-  padding: 28px;
-  color: var(--white);
-  background: var(--forest-deep);
-  border-right: 1px solid rgba(255, 255, 255, 0.35);
-}
-.activity-tile img {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.5s ease;
-}
-.activity-tile::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: rgba(5, 17, 12, 0.34);
-}
-.activity-tile:hover img {
-  transform: scale(1.03);
-}
-.activity-tile-content {
-  position: relative;
-  z-index: 2;
-}
-.activity-tile .h3 {
-  margin-bottom: 8px;
-}
-.activity-tile p {
-  margin: 0;
 }
 
 .page-hero {
@@ -1610,12 +1509,6 @@ p {
   .site-header {
     height: var(--header-h);
   }
-  .hero {
-    min-height: 74svh;
-  }
-  .hero::before {
-    background: rgba(6, 18, 13, 0.42);
-  }
   .intro-grid,
   .activity-guide,
   .page-hero-inner,
@@ -1624,14 +1517,6 @@ p {
   }
   .page-hero .lede {
     justify-self: start;
-  }
-  .activity-strip {
-    grid-template-columns: 1fr;
-  }
-  .activity-tile {
-    min-height: 60svh;
-    border-right: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.35);
   }
   .plp-layout {
     grid-template-columns: 1fr;
@@ -1734,22 +1619,6 @@ p {
   }
   .menu-button {
     padding-inline: 8px;
-  }
-  .hero {
-    padding-bottom: 46px;
-  }
-  .hero-content {
-    width: 100%;
-    min-width: 0;
-    max-width: 100%;
-  }
-  .hero .display {
-    max-width: 100%;
-    font-size: clamp(44px, 13vw, 52px);
-    text-wrap: wrap;
-  }
-  .hero-sub {
-    font-size: 16px;
   }
   .hero-actions {
     align-items: stretch;
@@ -2046,286 +1915,7 @@ body {
   background: var(--orange);
   border-radius: 50%;
 }
-.hero-advanced {
-  min-height: max(810px, calc(100svh - 30px));
-  display: block;
-  padding: 0;
-  background: var(--sand);
-  color: var(--ink);
-  overflow: hidden;
-}
-.hero-advanced::before {
-  display: none;
-}
-.hero-media {
-  position: absolute;
-  z-index: 0;
-  top: 6%;
-  right: 7%;
-  bottom: 7%;
-  width: 58%;
-  overflow: hidden;
-  background: var(--ink);
-}
-.hero-media::after {
-  display: none;
-}
-.hero-media .hero-image {
-  position: absolute;
-  inset: 0;
-  height: 100%;
-  object-fit: cover;
-  object-position: left center;
-  filter: saturate(0.72) contrast(1.05);
-}
-.hero-media-note {
-  position: absolute;
-  z-index: 2;
-  right: 0;
-  bottom: 0;
-  padding: 10px 12px;
-  background: var(--orange);
-  color: var(--ink);
-  font-family: var(--ui);
-  font-size: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-.hero-field-index {
-  position: absolute;
-  z-index: 2;
-  top: 8%;
-  left: var(--pad);
-  bottom: 8%;
-  width: 52px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-start;
-  padding-right: 16px;
-  border-right: 1px solid var(--ink);
-  font-family: var(--ui);
-  font-size: 7px;
-  letter-spacing: 0.12em;
-  writing-mode: vertical-rl;
-}
-.hero-field-index b {
-  color: var(--orange-dark);
-  font-weight: 500;
-}
-.hero-advanced .hero-content {
-  position: absolute;
-  z-index: 3;
-  left: clamp(92px, 10vw, 170px);
-  top: 16%;
-  width: min(1220px, 83vw);
-}
-.hero-advanced .eyebrow {
-  margin-left: 2px;
-  color: var(--ink);
-}
-.hero-advanced .display {
-  max-width: none;
-  font-size: clamp(72px, 9vw, 144px);
-  line-height: 0.86;
-  letter-spacing: -0.042em;
-}
-.hero-advanced .display span,
-.hero-advanced .display em {
-  display: block;
-}
-.mobile-only-break {
-  display: none;
-}
-.hero-advanced .display span {
-  width: max-content;
-  max-width: 720px;
-  padding: 0 0.12em 0.06em 0;
-  background: var(--sand);
-}
-.hero-advanced .display em {
-  width: max-content;
-  margin-left: clamp(24vw, 30vw, 430px);
-  padding: 0 0.14em 0.07em;
-  background: var(--sand);
-  color: var(--ink);
-  font-size: 0.7em;
-  font-weight: 500;
-  text-shadow: none;
-  white-space: nowrap;
-}
-.hero-advanced .hero-sub {
-  width: min(360px, 32vw);
-  margin: clamp(28px, 3.5vw, 48px) 0 25px;
-  padding: 17px 20px;
-  border-left: 1px solid var(--ink);
-  background: var(--sand);
-  font-size: 14px;
-}
-.hero-advanced .hero-actions {
-  align-items: center;
-}
-.hero-journal-link {
-  margin-left: 12px;
-  color: var(--ink);
-}
-.hero-condition {
-  position: absolute;
-  z-index: 3;
-  right: 7%;
-  bottom: 7%;
-  width: 230px;
-  display: grid;
-  padding: 18px;
-  border: 1px solid rgba(245, 241, 232, 0.75);
-  background: rgba(17, 19, 15, 0.86);
-  color: var(--white);
-  font-family: var(--ui);
-  font-size: 8px;
-  text-transform: uppercase;
-}
-.hero-condition span {
-  margin-bottom: 15px;
-  color: var(--orange);
-  letter-spacing: 0.12em;
-}
-.hero-condition strong {
-  padding-block: 7px;
-  border-top: 1px solid rgba(255, 255, 255, 0.25);
-  font-weight: 400;
-}
-.hero-condition i {
-  margin-top: 12px;
-  color: #a6aa9e;
-  font-style: normal;
-}
 
-.manifesto {
-  position: relative;
-  display: grid;
-  grid-template-columns: 100px 0.85fr 1fr;
-  gap: clamp(30px, 6vw, 100px);
-  padding-block: clamp(110px, 13vw, 210px);
-}
-.manifesto-number {
-  font-family: var(--display);
-  font-size: 140px;
-  line-height: 0.7;
-  color: transparent;
-  -webkit-text-stroke: 1px var(--stone-dark);
-}
-.manifesto .h2 i {
-  color: var(--orange-dark);
-}
-.manifesto-copy {
-  padding-top: 10px;
-}
-.manifesto-ledger {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin: 38px 0;
-  border-block: 1px solid var(--line);
-}
-.manifesto-ledger span {
-  padding: 15px 10px 15px 0;
-  font-family: var(--ui);
-  font-size: 8px;
-  text-transform: uppercase;
-}
-.manifesto-ledger b {
-  display: block;
-  margin-bottom: 6px;
-  font-family: var(--display);
-  font-size: 31px;
-  font-weight: 400;
-}
-
-.image-dossier {
-  min-height: 900px;
-  position: relative;
-  padding-bottom: 110px;
-}
-.image-dossier figure {
-  margin: 0;
-}
-.image-dossier img {
-  height: 100%;
-  object-fit: cover;
-  filter: saturate(0.72);
-}
-.image-dossier figcaption {
-  margin-top: 8px;
-  font-family: var(--ui);
-  font-size: 8px;
-  text-transform: uppercase;
-}
-.dossier-main {
-  width: 63%;
-  height: 770px;
-}
-.dossier-inset {
-  position: absolute;
-  right: 8%;
-  top: 20%;
-  width: 34%;
-  height: 460px;
-  padding: 12px;
-  background: var(--paper);
-  box-shadow: -24px 24px 0 var(--orange);
-}
-.dossier-stamp {
-  position: absolute;
-  right: 40%;
-  top: 70px;
-  width: 145px;
-  height: 145px;
-  display: grid;
-  place-content: center;
-  text-align: center;
-  border: 1px solid var(--ink);
-  border-radius: 50%;
-  transform: rotate(11deg);
-  font-family: var(--ui);
-  font-size: 7px;
-  text-transform: uppercase;
-}
-.dossier-stamp b {
-  display: block;
-  margin-block: 8px;
-  font-family: var(--display);
-  font-size: 24px;
-  font-weight: 400;
-}
-.dossier-caption {
-  position: absolute;
-  top: 72%;
-  right: 8%;
-  width: min(390px, 34%);
-  margin: 0;
-  padding-top: 25px;
-  border-top: 1px solid var(--ink);
-  background: var(--paper);
-  font-family: var(--display);
-  font-size: clamp(24px, 2.7vw, 39px);
-  line-height: 1.12;
-}
-
-.equipment-runway {
-  padding-top: 70px;
-}
-.runway-head {
-  align-items: flex-end;
-}
-.runway-head .h2 i {
-  color: var(--orange-dark);
-}
-.runway-note {
-  align-self: center;
-  font-family: var(--ui);
-  font-size: 8px;
-  line-height: 1.8;
-  text-transform: uppercase;
-}
 .product-grid {
   gap: 18px;
   border: 0;
@@ -2366,127 +1956,7 @@ body {
   font-weight: 600;
   text-transform: uppercase;
 }
-.product-runway {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  align-items: start;
-}
 
-.dispatch-feature {
-  min-height: 820px;
-  position: relative;
-  display: grid;
-  grid-template-columns: 1.25fr 0.75fr;
-  overflow: hidden;
-  background: var(--ink);
-}
-.dispatch-image {
-  min-height: 820px;
-  position: relative;
-}
-.dispatch-image img {
-  height: 100%;
-  object-fit: cover;
-  filter: grayscale(0.2) saturate(0.7);
-}
-.dispatch-image span {
-  position: absolute;
-  left: 20px;
-  bottom: 18px;
-  padding: 8px 10px;
-  background: var(--orange);
-  color: var(--ink);
-  font-family: var(--ui);
-  font-size: 8px;
-  text-transform: uppercase;
-}
-.dispatch-feature .field-copy {
-  position: relative;
-  z-index: 2;
-  padding: clamp(55px, 7vw, 105px);
-}
-.dispatch-feature .field-copy .h2 {
-  font-size: clamp(54px, 6.2vw, 92px);
-}
-.dispatch-feature .field-copy .h2 i {
-  color: var(--orange);
-  font-weight: 400;
-}
-.dispatch-feature blockquote {
-  max-width: 470px;
-  margin: 50px 0 0;
-  padding-top: 20px;
-  border-top: 1px solid #73786d;
-  font-family: var(--display);
-  font-size: 24px;
-  font-style: italic;
-}
-.dispatch-issue {
-  position: absolute;
-  z-index: 1;
-  right: -20px;
-  bottom: -70px;
-  color: transparent;
-  -webkit-text-stroke: 1px #41463e;
-  font-family: var(--display);
-  font-size: 300px;
-  line-height: 1;
-}
-.ground-index .activity-strip {
-  grid-template-columns: 0.75fr 1.3fr 0.95fr;
-  gap: 14px;
-}
-.ground-index .activity-tile {
-  min-height: 620px;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  align-items: stretch;
-  padding: 0;
-  border: 0;
-  background: var(--ink);
-}
-.ground-index .activity-tile:nth-child(1) {
-  margin-top: 90px;
-}
-.ground-index .activity-tile:nth-child(3) {
-  margin-top: 180px;
-}
-.ground-index .activity-tile img {
-  position: relative;
-  inset: auto;
-  min-height: 430px;
-  object-position: center;
-}
-.ground-index .activity-tile:nth-child(1) img {
-  object-position: 58% center;
-}
-.ground-index .activity-tile:nth-child(2) img {
-  object-position: 64% center;
-}
-.ground-index .activity-tile:nth-child(3) img {
-  object-position: center 38%;
-}
-.ground-index .activity-tile-content {
-  min-height: 150px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: 22px;
-  background: var(--ink);
-}
-.ground-index .activity-tile-content p {
-  margin-bottom: 0;
-}
-.tile-index {
-  position: absolute;
-  z-index: 2;
-  top: 20px;
-  left: 20px;
-  font-family: var(--display);
-  font-size: 64px;
-}
-.ground-index .activity-tile::after {
-  display: none;
-}
 .page-hero {
   min-height: 560px;
   display: flex;
@@ -3191,20 +2661,11 @@ a.check-row[aria-current] .check-dot {
   .site-header {
     grid-template-columns: 1fr auto;
   }
-  .product-runway {
-    grid-template-columns: 1fr 1fr;
-  }
   .plp-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .pdp {
     grid-template-columns: minmax(360px, 0.88fr) minmax(0, 1.12fr);
-  }
-  .manifesto {
-    grid-template-columns: 80px 1fr;
-  }
-  .manifesto-copy {
-    grid-column: 2;
   }
   .footer-col:last-child {
     display: block;
@@ -3222,103 +2683,6 @@ a.check-row[aria-current] .check-dot {
   }
   .announcement {
     justify-content: center;
-  }
-  .hero-advanced {
-    min-height: 900px;
-  }
-  .hero-media {
-    top: 18px;
-    right: 18px;
-    bottom: auto;
-    width: calc(100% - 36px);
-    height: 42%;
-  }
-  .hero-media .hero-image {
-    object-position: 18% center;
-  }
-  .hero-advanced .hero-content {
-    left: var(--pad);
-    top: 46%;
-    width: calc(100% - var(--pad) * 2);
-  }
-  .hero-advanced .display {
-    font-size: clamp(62px, 13vw, 96px);
-  }
-  .hero-advanced .display span {
-    width: auto;
-    background: transparent;
-  }
-  .hero-advanced .display em {
-    width: auto;
-    margin-left: 0;
-    padding: 0;
-    background: transparent;
-    color: var(--ink);
-    font-size: 0.82em;
-    white-space: normal;
-  }
-  .hero-advanced .hero-sub {
-    width: min(440px, 100%);
-    background: transparent;
-  }
-  .hero-field-index {
-    display: none;
-  }
-  .hero-condition {
-    display: none;
-  }
-  .manifesto {
-    grid-template-columns: 1fr;
-  }
-  .manifesto-number {
-    position: absolute;
-    right: var(--pad);
-    top: 110px;
-    opacity: 0.6;
-  }
-  .manifesto-copy {
-    grid-column: auto;
-  }
-  .dossier-main {
-    width: 78%;
-    height: 650px;
-  }
-  .dossier-inset {
-    right: var(--pad);
-    top: 35%;
-    width: 43%;
-    height: 330px;
-  }
-  .dossier-stamp {
-    right: 4%;
-    top: 40px;
-  }
-  .dossier-caption {
-    top: auto;
-    width: 48%;
-    right: 4%;
-    bottom: 20px;
-  }
-  .dispatch-feature {
-    grid-template-columns: 1fr;
-  }
-  .dispatch-image {
-    min-height: 62svh;
-  }
-  .dispatch-feature .field-copy {
-    margin-top: -140px;
-    background: var(--ink);
-    width: 86%;
-  }
-  .ground-index .activity-strip {
-    grid-template-columns: 1fr;
-  }
-  .ground-index .activity-tile:nth-child(n) {
-    margin-top: 0;
-    min-height: 0;
-  }
-  .ground-index .activity-tile img {
-    min-height: 440px;
   }
   .page-hero {
     min-height: 520px;
@@ -3404,90 +2768,6 @@ a.check-row[aria-current] .check-dot {
   .brand small {
     font-size: 6px;
   }
-  .hero-advanced {
-    min-height: 860px;
-  }
-  .hero-media {
-    top: 12px;
-    right: 12px;
-    width: calc(100% - 24px);
-    height: 320px;
-  }
-  .hero-advanced .hero-content {
-    top: 350px;
-  }
-  .hero-advanced .display {
-    font-size: clamp(52px, 14.5vw, 68px);
-    line-height: 0.9;
-  }
-  .hero-advanced .display em {
-    margin-left: 0;
-  }
-  .mobile-only-break {
-    display: block;
-  }
-  .hero-advanced .hero-sub {
-    width: 100%;
-    margin-top: 24px;
-  }
-  .hero-advanced .hero-actions {
-    align-items: stretch;
-    flex-direction: column;
-  }
-  .hero-journal-link {
-    margin-left: 0;
-  }
-  .manifesto-number {
-    font-size: 90px;
-  }
-  .manifesto-ledger {
-    grid-template-columns: 1fr;
-  }
-  .manifesto-ledger span {
-    border-bottom: 1px solid var(--line);
-  }
-  .image-dossier {
-    min-height: 780px;
-    padding-inline: 12px;
-  }
-  .dossier-main {
-    width: 86%;
-    height: 500px;
-  }
-  .dossier-inset {
-    width: 52%;
-    height: 260px;
-    right: 12px;
-    top: 44%;
-    padding: 7px;
-    box-shadow: -10px 10px 0 var(--orange);
-  }
-  .dossier-stamp {
-    width: 105px;
-    height: 105px;
-    right: 3%;
-    top: 25px;
-  }
-  .dossier-stamp b {
-    font-size: 17px;
-  }
-  .dossier-caption {
-    top: auto;
-    width: 58%;
-    right: 3%;
-    bottom: 10px;
-    font-size: 21px;
-  }
-  .ground-index .activity-tile img {
-    min-height: 360px;
-  }
-  .runway-head {
-    align-items: flex-start;
-  }
-  .runway-note {
-    display: none;
-  }
-  .product-runway,
   .product-grid {
     grid-template-columns: 1fr 1fr;
     gap: 10px;
@@ -3495,19 +2775,6 @@ a.check-row[aria-current] .check-dot {
 
   .product-name {
     font-size: 15px;
-  }
-  .dispatch-image {
-    min-height: 54svh;
-  }
-  .dispatch-feature .field-copy {
-    width: 94%;
-    padding: 38px 24px 70px;
-  }
-  .dispatch-issue {
-    font-size: 180px;
-  }
-  .dispatch-issue {
-    right: 0;
   }
   .page-hero {
     min-height: 430px;
@@ -3567,18 +2834,6 @@ a.check-row[aria-current] .check-dot {
     display: block;
   }
 
-  /* Mobile cascade guard: these rules intentionally follow the advanced
-   * desktop overrides above so narrow layouts cannot retain desktop geometry. */
-  .hero-advanced .hero-content {
-    min-width: 0;
-    overflow: hidden;
-  }
-  .hero-advanced .hero-sub {
-    box-sizing: border-box;
-    min-width: 0;
-    max-width: 100%;
-    overflow-wrap: anywhere;
-  }
   .page-hero-inner {
     grid-template-columns: minmax(0, 1fr);
     gap: 28px;

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -12,8 +12,9 @@ import {
   storefrontRuntimeMode,
 } from "@/lib/storefront/data-source";
 import {
-  productColorwayHref,
+  productSelectionHref,
   resolveColorway,
+  resolveProductSelection,
 } from "@/lib/storefront/product-state";
 
 export const metadata: Metadata = {
@@ -34,17 +35,26 @@ async function buildSeedLines(): Promise<readonly DemoCartLine[]> {
       continue;
     }
     const colorway = resolveColorway(product, entry.colorwayId);
+    const selection = resolveProductSelection(product, colorway.id, {
+      Size: entry.size,
+    });
     lines.push({
-      key: lineKey(product.handle, colorway.id, entry.size),
+      key: lineKey(product.handle, selection.variant.id),
+      variantId: selection.variant.id,
       productHandle: product.handle,
       title: product.title,
       colorwayId: colorway.id,
       colorwayName: colorway.name,
       size: entry.size,
+      selectedOptions: selection.selectedOptions,
       quantity: entry.quantity,
-      unitPrice: product.price,
+      unitPrice: selection.variant.price,
       image: colorway.images.primary,
-      href: productColorwayHref(product, colorway.id),
+      href: productSelectionHref(
+        product,
+        colorway.id,
+        selection.selectedOptions,
+      ),
     });
   }
   return lines;

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -45,7 +45,6 @@ async function buildSeedLines(): Promise<readonly DemoCartLine[]> {
       title: product.title,
       colorwayId: colorway.id,
       colorwayName: colorway.name,
-      size: entry.size,
       selectedOptions: selection.selectedOptions,
       quantity: entry.quantity,
       unitPrice: selection.variant.price,

--- a/src/app/field-testing/page.tsx
+++ b/src/app/field-testing/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+import { storefront } from "@/lib/storefront/data-source";
+
+export const metadata: Metadata = {
+  title: "Field Testing",
+  description: "How Forward evaluates products before they enter the catalog.",
+};
+
+export default async function FieldTestingCustomPage() {
+  const [theme, products, articles] = await Promise.all([
+    storefront.getThemeContent(),
+    storefront.listProducts(),
+    storefront.listArticles(),
+  ]);
+  const shell = products.find(
+    (product) => product.handle === "weatherline-shell",
+  );
+  const shellImage = shell?.colorways[0]?.images.context;
+  const testingArticle = articles.find((article) =>
+    article.handle.includes("test-a-shell"),
+  );
+  return (
+    <div className="custom-story-page testing-page">
+      <section className="testing-hero">
+        <Image
+          src={theme.homeHeroImage.src}
+          alt={theme.homeHeroImage.alt}
+          width={theme.homeHeroImage.width}
+          height={theme.homeHeroImage.height}
+          sizes="100vw"
+          priority
+        />
+        <div>
+          <p className="eyebrow">Custom page / Field testing</p>
+          <h1>Test the system, not the claim.</h1>
+          <p>
+            Wind, rain, abrasion, repeated packing, and long movement reveal
+            more than an isolated specification ever will.
+          </p>
+        </div>
+      </section>
+      <section className="testing-sequence shell section">
+        <header>
+          <p className="eyebrow">The sequence</p>
+          <h2 className="h2">From controlled checks to useful failure.</h2>
+        </header>
+        <ol>
+          <li>
+            <span className="testing-sequence-number">01</span>
+            <div>
+              <h3>Baseline</h3>
+              <p>
+                Confirm construction, fit, range of movement, and every
+                functional detail before field use.
+              </p>
+            </div>
+          </li>
+          <li>
+            <span className="testing-sequence-number">02</span>
+            <div>
+              <h3>Exposure</h3>
+              <p>
+                Use the product through realistic weather and terrain in
+                combination with the complete system.
+              </p>
+            </div>
+          </li>
+          <li>
+            <span className="testing-sequence-number">03</span>
+            <div>
+              <h3>Repetition</h3>
+              <p>
+                Pack, wash, adjust, and wear repeatedly to surface friction,
+                fatigue, and awkward interactions.
+              </p>
+            </div>
+          </li>
+          <li>
+            <span className="testing-sequence-number">04</span>
+            <div>
+              <h3>Repair review</h3>
+              <p>
+                Evaluate how failure can be diagnosed and repaired before a
+                product earns a permanent place.
+              </p>
+            </div>
+          </li>
+        </ol>
+      </section>
+      {shell !== undefined && shellImage !== undefined ? (
+        <section className="testing-product">
+          <div>
+            <p className="eyebrow">Case study / Weatherline</p>
+            <h2>{shell.title}</h2>
+            <p>{shell.description}</p>
+            <dl>
+              {shell.specs.map((spec) => (
+                <div key={spec.label}>
+                  <dt>{spec.label}</dt>
+                  <dd>{spec.value}</dd>
+                </div>
+              ))}
+            </dl>
+            <Link
+              className="button button-light"
+              href={`/products/${shell.handle}`}
+            >
+              View the shell
+            </Link>
+          </div>
+          <Image
+            src={shellImage.src}
+            alt={shellImage.alt}
+            width={shellImage.width}
+            height={shellImage.height}
+            sizes="(min-width: 820px) 55vw, 100vw"
+          />
+        </section>
+      ) : null}
+      {testingArticle !== undefined ? (
+        <section className="custom-story-cta shell section">
+          <div>
+            <p className="eyebrow">Field note</p>
+            <h2 className="h2">Read the complete shell protocol.</h2>
+          </div>
+          <p>{testingArticle.excerpt}</p>
+          <Link
+            className="button button-primary"
+            href={`/journal/${testingArticle.handle}`}
+          >
+            Open field note
+          </Link>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/field-testing/page.tsx
+++ b/src/app/field-testing/page.tsx
@@ -19,8 +19,9 @@ export default async function FieldTestingCustomPage() {
     (product) => product.handle === "weatherline-shell",
   );
   const shellImage = shell?.colorways[0]?.images.context;
-  const testingArticle = articles.find((article) =>
-    article.handle.includes("test-a-shell"),
+  const testingArticle = articles.find(
+    (article) =>
+      article.handle === "how-we-test-a-shell-before-calling-it-weatherproof",
   );
   return (
     <div className="custom-story-page testing-page">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { IBM_Plex_Mono, Manrope, Space_Grotesk } from "next/font/google";
+import { Archivo, IBM_Plex_Mono, Manrope } from "next/font/google";
 import type { ReactNode } from "react";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -11,13 +11,13 @@ import "./globals.css";
 import "./canonical-source.css";
 import "./site-header.css";
 
-/* Premium type contract: Space Grotesk for display, Manrope for body/UI, and
+/* Premium type contract: Archivo for display, Manrope for body/UI, and
  * IBM Plex Mono only for compact field metadata. Next serves all three. */
-const spaceGrotesk = Space_Grotesk({
+const archivo = Archivo({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
   display: "swap",
-  variable: "--font-space-grotesk",
+  variable: "--font-archivo",
 });
 
 const manrope = Manrope({
@@ -52,7 +52,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${spaceGrotesk.variable} ${manrope.variable} ${plexMono.variable}`}
+      className={`${archivo.variable} ${manrope.variable} ${plexMono.variable}`}
     >
       <head>
         {shopifyCartEnabled ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { IBM_Plex_Mono, Literata, Manrope } from "next/font/google";
+import { IBM_Plex_Mono, Manrope, Space_Grotesk } from "next/font/google";
 import type { ReactNode } from "react";
 
 import { SiteFooter } from "@/components/site-footer";
@@ -11,28 +11,13 @@ import "./globals.css";
 import "./canonical-source.css";
 import "./site-header.css";
 
-/*
- * Canonical font contract, ported from the Advanced POC document head
- * (source `index.html:11`): Literata (display), Manrope (UI), IBM Plex Mono
- * (field labels). Served by Next instead of hotlinked from Google Fonts.
- *
- * The source requests `Literata:opsz,wght@7..72,400;7..72,500;7..72,600` — the
- * variable font including its optical-size axis. Declaring discrete weights
- * here would download static instances cut at the default `opsz` of 14, the
- * text optical size, so the oversized display headlines would render in a
- * body-text cut: blunter serifs, lower stroke contrast, looser spacing.
- * Requesting the `opsz` axis instead lets the browser's default
- * `font-optical-sizing: auto` pick the display cut at hero sizes, and the
- * variable `wght` axis still covers every weight the stylesheet asks for.
- *
- * Manrope and IBM Plex Mono stay on discrete weights because the source
- * requests them the same way (`wght@400;500;600;700` and `wght@400;500`).
- */
-const literata = Literata({
+/* Premium type contract: Space Grotesk for display, Manrope for body/UI, and
+ * IBM Plex Mono only for compact field metadata. Next serves all three. */
+const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
-  axes: ["opsz"],
+  weight: ["400", "500", "600", "700"],
   display: "swap",
-  variable: "--font-literata",
+  variable: "--font-space-grotesk",
 });
 
 const manrope = Manrope({
@@ -67,7 +52,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${literata.variable} ${manrope.variable} ${plexMono.variable}`}
+      className={`${spaceGrotesk.variable} ${manrope.variable} ${plexMono.variable}`}
     >
       <head>
         {shopifyCartEnabled ? (

--- a/src/app/materials/page.tsx
+++ b/src/app/materials/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+import { storefront } from "@/lib/storefront/data-source";
+
+export const metadata: Metadata = {
+  title: "Materials",
+  description: "Forward material choices, care principles, and repair intent.",
+};
+
+export default async function MaterialsCustomPage() {
+  const [theme, products] = await Promise.all([
+    storefront.getThemeContent(),
+    storefront.listProducts(),
+  ]);
+  const representatives = [products[0], products[3], products[6]].flatMap(
+    (product) => {
+      const image = product?.colorways[0]?.images.detail;
+      return product === undefined || image === undefined
+        ? []
+        : [{ product, image }];
+    },
+  );
+  return (
+    <div className="custom-story-page material-page">
+      <section className="custom-story-hero custom-story-hero-reverse">
+        <div>
+          <p className="eyebrow">Custom page / Material library</p>
+          <h1>Performance begins with what a product is made from.</h1>
+          <p className="lede">
+            We use a short material vocabulary, document what each element is
+            for, and design care around extending its useful life.
+          </p>
+        </div>
+        <Image
+          src={theme.standardBandImage.src}
+          alt={theme.standardBandImage.alt}
+          width={theme.standardBandImage.width}
+          height={theme.standardBandImage.height}
+          sizes="(min-width: 820px) 55vw, 100vw"
+          priority
+        />
+      </section>
+      <section className="material-principles shell section">
+        {[
+          [
+            "01",
+            "Protect without excess",
+            "Shell fabrics and insulation are tuned around weather protection, movement, and packability—not maximum numbers in isolation.",
+          ],
+          [
+            "02",
+            "Carry without distraction",
+            "Foams, webbing, and hardware are selected to stabilize a load while keeping adjustment and repair straightforward.",
+          ],
+          [
+            "03",
+            "Grip with feedback",
+            "Footwear compounds balance traction, ground feel, and controlled wear across mixed trail and rock.",
+          ],
+        ].map(([number, title, copy]) => (
+          <article key={number}>
+            <span className="material-principle-number">{number}</span>
+            <h2>{title}</h2>
+            <p>{copy}</p>
+          </article>
+        ))}
+      </section>
+      <section className="material-product-band">
+        {representatives.map(({ product, image }) => (
+          <Link href={`/products/${product.handle}`} key={product.handle}>
+            <Image
+              src={image.src}
+              alt={image.alt}
+              width={image.width}
+              height={image.height}
+              sizes="(min-width: 820px) 34vw, 100vw"
+            />
+            <div>
+              <span>{product.category}</span>
+              <strong>{product.title}</strong>
+              <span>Inspect product →</span>
+            </div>
+          </Link>
+        ))}
+      </section>
+      <section className="custom-story-cta shell section">
+        <div>
+          <p className="eyebrow">Care + repair</p>
+          <h2 className="h2">Maintenance is part of performance.</h2>
+        </div>
+        <p>
+          Clean only when needed, restore water repellency before replacing a
+          shell, and send structural damage to the repair desk.
+        </p>
+        <Link className="button button-primary" href="/pages/field-repair">
+          Repair programme
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function HomePage() {
   const pack = productsByHandle.get("approach-18-day-pack") ?? featured[1];
   const dispatch = articles[0];
   const spotlightImage = spotlight?.colorways[0]?.images.context;
-  const kitProducts = featured.flatMap((product) => {
+  const kitProducts = featured.slice(0, 3).flatMap((product) => {
     const image = product.colorways[0]?.images.primary;
     return image === undefined ? [] : [{ product, image }];
   });
@@ -228,7 +228,7 @@ export default async function HomePage() {
             </Link>
           </div>
           <div className="home-kit-products">
-            {kitProducts.slice(0, 3).map(({ product, image }) => (
+            {kitProducts.map(({ product, image }) => (
               <Link href={`/products/${product.handle}`} key={product.handle}>
                 <Image
                   src={image.src}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,100 +5,82 @@ import { ProductCard } from "@/components/product-card";
 import { storefront } from "@/lib/storefront/data-source";
 import type { Collection, Product } from "@/lib/storefront/types";
 
-/*
- * Home — a one-to-one port of the canonical `homePage()` (source
- * `app.js:212–250`): hero dossier, operating premise, image dossier, equipment
- * runway, dispatch feature, and the movement-system ground index.
- *
- * Roles resolve by stable handle through the normalized data source, never by
- * array index and never from fixtures directly:
- *
- *   IMG.climbing -> themeContent.homeHeroImage
- *   IMG.hike     -> collection `outerwear` hero
- *   IMG.tent     -> collection `packs` hero
- *   IMG.ridge    -> themeContent.standardBandImage
- *   runway       -> ridge-30-field-pack, weatherline-shell, talus-trail-shoe
- *   tiles        -> outerwear, packs, footwear
- *   dispatch     -> first normalized journal article
- *
- * The canonical runway carries four fictional products; Forward has three real
- * ones. That count difference is intentional — no fourth product is invented.
- */
+export const revalidate = 3600;
 
-const RUNWAY_HANDLES = [
-  "ridge-30-field-pack",
+const FEATURED_HANDLES = [
   "weatherline-shell",
+  "traverse-grid-fleece",
+  "ridge-30-field-pack",
   "talus-trail-shoe",
 ] as const;
 
-const TILE_HANDLES = ["outerwear", "packs", "footwear"] as const;
-
-/* Bounded catalog freshness — see the note on `/products/[productHandle]`. */
-export const revalidate = 3600;
-
-/** Splits a title so the canonical two-line headline treatment still works. */
-function splitTitle(title: string): { lead: string; rest: string } {
-  const firstSpace = title.indexOf(" ");
-  if (firstSpace === -1) {
-    return { lead: title, rest: "" };
-  }
-  return {
-    lead: title.slice(0, firstSpace),
-    rest: title.slice(firstSpace + 1),
-  };
-}
-
-/** First sentence of a normalized description, for the compact tile copy. */
-function firstSentence(text: string): string {
-  const end = text.indexOf(". ");
-  return end === -1 ? text : text.slice(0, end + 1);
-}
+const CATEGORY_HANDLES = ["outerwear", "packs", "footwear"] as const;
 
 export default async function HomePage() {
-  const [themeContent, allProducts, allCollections, articles] =
-    await Promise.all([
-      storefront.getThemeContent(),
-      storefront.listProducts(),
-      storefront.listCollections(),
-      storefront.listArticles(),
-    ]);
-
-  const byHandle = new Map<string, Product>(
-    allProducts.map((product) => [product.handle, product]),
+  const [themeContent, products, collections, articles] = await Promise.all([
+    storefront.getThemeContent(),
+    storefront.listProducts(),
+    storefront.listCollections(),
+    storefront.listArticles(),
+  ]);
+  const productsByHandle = new Map<string, Product>(
+    products.map((product) => [product.handle, product]),
   );
   const collectionsByHandle = new Map<string, Collection>(
-    allCollections.map((collection) => [collection.handle, collection]),
+    collections.map((collection) => [collection.handle, collection]),
   );
-
-  const runway = RUNWAY_HANDLES.map((handle) => byHandle.get(handle)).filter(
-    (product): product is Product => product !== undefined,
-  );
-  const tiles = TILE_HANDLES.map((handle) =>
+  const featured = FEATURED_HANDLES.map((handle) =>
+    productsByHandle.get(handle),
+  ).filter((product): product is Product => product !== undefined);
+  const categories = CATEGORY_HANDLES.map((handle) =>
     collectionsByHandle.get(handle),
   ).filter((collection): collection is Collection => collection !== undefined);
-
-  const traverseImage = collectionsByHandle.get("outerwear")?.heroImage;
-  const campImage = collectionsByHandle.get("packs")?.heroImage;
+  const spotlight = productsByHandle.get("drift-insulated-vest") ?? featured[0];
+  const pack = productsByHandle.get("approach-18-day-pack") ?? featured[1];
   const dispatch = articles[0];
-  const dispatchTitle =
-    dispatch !== undefined ? splitTitle(dispatch.title) : undefined;
-  const dispatchQuote = dispatch?.body.find(
-    (block) => block.type === "pullquote",
-  );
-  const dispatchNumber = dispatch?.plate.replace(/\D/g, "") ?? "01";
+  const spotlightImage = spotlight?.colorways[0]?.images.context;
+  const kitProducts = featured.flatMap((product) => {
+    const image = product.colorways[0]?.images.primary;
+    return image === undefined ? [] : [{ product, image }];
+  });
 
   return (
-    <div className="home-advanced">
-      <section className="hero hero-advanced">
-        <div className="hero-field-index" aria-hidden="true">
-          <b>FORWARD / 01</b>
-          <span>SPRING—AUTUMN</span>
-          <span>54° 27′ 39″ N</span>
-          <span>RANGE / WESTERN FELLS</span>
+    <div className="commerce-home">
+      <section className="commerce-hero">
+        <div className="commerce-hero-copy">
+          <p className="eyebrow">Forward / Field equipment 2026</p>
+          <h1 className="display">
+            Equipment for weather that changes the plan.
+          </h1>
+          <p className="lede">
+            Layerable apparel, precise footwear, and low-profile carry systems
+            made to move together.
+          </p>
+          <div className="commerce-hero-actions">
+            <Link className="button button-signal" href="/shop">
+              Shop all equipment
+            </Link>
+            <Link className="text-link" href="/field-testing">
+              How we test
+            </Link>
+          </div>
+          <dl className="commerce-hero-facts">
+            <div>
+              <dt>Systems</dt>
+              <dd>{categories.length}</dd>
+            </div>
+            <div>
+              <dt>Core objects</dt>
+              <dd>{products.length}</dd>
+            </div>
+            <div>
+              <dt>Repair</dt>
+              <dd>For life</dd>
+            </div>
+          </dl>
         </div>
-        <div className="hero-media">
+        <div className="commerce-hero-media">
           <Image
-            className="hero-image"
             src={themeContent.homeHeroImage.src}
             alt={themeContent.homeHeroImage.alt}
             width={themeContent.homeHeroImage.width}
@@ -106,205 +88,57 @@ export default async function HomePage() {
             sizes="(min-width: 820px) 58vw, 100vw"
             priority
           />
-          <span className="hero-media-note">
-            Plate 01 / Open sky, east face
-          </span>
-        </div>
-        <div className="hero-content">
-          <p className="eyebrow">FORWARD / High country system</p>
-          <h1 className="display">
-            <span>Move until</span>
-            <em>
-              the map
-              <br className="mobile-only-break" /> runs out.
-            </em>
-          </h1>
-          <p className="hero-sub">
-            Purposeful layers and field equipment for uncertain weather, useful
-            distance, and the quiet beyond the marked route.
-          </p>
-          <div className="hero-actions">
-            <Link className="button button-signal" href="/shop">
-              Enter the equipment index
+          {featured[0] !== undefined ? (
+            <Link
+              className="commerce-hero-product"
+              href={`/products/${featured[0].handle}`}
+            >
+              <span className="commerce-hero-product-meta">
+                Featured system
+              </span>
+              <strong>{featured[0].title}</strong>
+              <span className="commerce-hero-product-meta">View product →</span>
             </Link>
-            {dispatch !== undefined ? (
-              <Link
-                className="text-link hero-journal-link"
-                href={`/journal/${dispatch.handle}`}
-              >
-                Dispatch {dispatch.plate}
-              </Link>
-            ) : null}
-          </div>
-        </div>
-        <div className="hero-condition">
-          <span>Current field condition</span>
-          <strong>Wind / W 18</strong>
-          <strong>Visibility / Open</strong>
-          <i>Static demonstration data</i>
+          ) : null}
         </div>
       </section>
 
-      <section className="manifesto section shell">
-        <div className="manifesto-number" aria-hidden="true">
-          01
-        </div>
-        <div>
-          <p className="eyebrow">Operating premise</p>
-          <h2 className="h2">
-            Carry less.
-            <br />
-            <i>Notice more.</i>
-          </h2>
-        </div>
-        <div className="manifesto-copy">
-          <p className="lede">
-            We build adaptable outdoor goods around a strict premise: every
-            piece must earn its weight, survive a change of plan, and become
-            quieter with use.
-          </p>
-          <div className="manifesto-ledger">
-            <span>
-              <b>{String(allProducts.length).padStart(2, "0")}</b> core objects
-            </span>
-            <span>
-              <b>{String(allCollections.length).padStart(2, "0")}</b> movement
-              systems
-            </span>
-            <span>
-              <b>01</b> lifetime repair desk
-            </span>
-          </div>
-          <Link className="text-link" href="/pages/about-forward">
-            Read the field standard
-          </Link>
-        </div>
-      </section>
-
-      <section className="image-dossier shell" aria-label="Field image dossier">
-        {traverseImage !== undefined ? (
-          <figure className="dossier-main">
-            <Image
-              src={traverseImage.src}
-              alt={traverseImage.alt}
-              width={traverseImage.width}
-              height={traverseImage.height}
-              sizes="(min-width: 560px) 63vw, 86vw"
-            />
-            <figcaption>Traverse study / 04</figcaption>
-          </figure>
-        ) : null}
-        {campImage !== undefined ? (
-          <figure className="dossier-inset">
-            <Image
-              src={campImage.src}
-              alt={campImage.alt}
-              width={campImage.width}
-              height={campImage.height}
-              sizes="(min-width: 560px) 34vw, 52vw"
-            />
-            <figcaption>Camp / 19:48</figcaption>
-          </figure>
-        ) : null}
-        <div className="dossier-stamp" aria-hidden="true">
-          <span>Tested beyond</span>
-          <b>3,000 FT</b>
-          <span>FORWARD / CUMBRIA</span>
-        </div>
-        <p className="dossier-caption">
-          A clothing system should disappear while moving and become exactly
-          enough when the weather turns.
-        </p>
-      </section>
-
-      <section className="equipment-runway section shell">
-        <div className="section-head runway-head">
+      <section className="home-shop-section section shell">
+        <header className="home-commerce-head">
           <div>
-            <p className="eyebrow">
-              Equipment index / 01—{String(runway.length).padStart(2, "0")}
-            </p>
-            <h2 className="h2">
-              Objects for
-              <br />
-              <i>going farther.</i>
-            </h2>
+            <p className="eyebrow">New field rotation</p>
+            <h2 className="h2">Start with the core four.</h2>
           </div>
-          <p className="runway-note">
-            Three pieces. One field system.
-            <br />
-            Built to layer, carry, and repair.
+          <p>
+            A weather layer, breathable midlayer, close-body carry, and trail
+            shoe form the shortest route to a complete Forward system.
           </p>
           <Link className="text-link" href="/shop">
-            Complete index
+            Shop all {products.length}
           </Link>
-        </div>
-        <div className="product-grid product-runway">
-          {runway.map((product, index) => (
+        </header>
+        <div className="product-grid home-featured-grid">
+          {featured.map((product, index) => (
             <ProductCard
               key={product.handle}
               product={product}
-              priority={index === 0}
+              priority={index < 2}
             />
           ))}
         </div>
       </section>
 
-      {dispatch !== undefined && dispatchTitle !== undefined ? (
-        <section className="field-notes dispatch-feature">
-          <div className="dispatch-image">
-            <Image
-              src={themeContent.standardBandImage.src}
-              alt={themeContent.standardBandImage.alt}
-              width={themeContent.standardBandImage.width}
-              height={themeContent.standardBandImage.height}
-              sizes="(min-width: 820px) 62vw, 100vw"
-            />
-            <span>
-              {dispatch.location} / {dispatch.readingMinutes} min read /{" "}
-              {dispatch.coordinates}
-            </span>
-          </div>
-          <div className="field-copy">
-            <p className="eyebrow">
-              Dispatch {dispatch.plate} / {dispatch.location}
-            </p>
-            <h2 className="h2">
-              {dispatchTitle.lead}
-              <br />
-              <i>{dispatchTitle.rest}</i>
-            </h2>
-            {dispatchQuote !== undefined ? (
-              <blockquote>“{dispatchQuote.text}”</blockquote>
-            ) : null}
-            <p>{dispatch.excerpt}</p>
+      <section className="home-system-section">
+        <header className="home-system-intro shell">
+          <p className="eyebrow">Shop by system</p>
+          <h2 className="h2">Built separately. Better together.</h2>
+        </header>
+        <div className="home-system-grid">
+          {categories.map((collection) => (
             <Link
-              className="button button-light"
-              href={`/journal/${dispatch.handle}`}
-            >
-              Open dispatch {dispatch.plate}
-            </Link>
-          </div>
-          <span className="dispatch-issue" aria-hidden="true">
-            {dispatchNumber}
-          </span>
-        </section>
-      ) : null}
-
-      <section className="ground-index section shell">
-        <div className="section-head">
-          <div>
-            <p className="eyebrow">
-              Movement systems / 01—{String(tiles.length).padStart(2, "0")}
-            </p>
-            <h2 className="h2">Choose your ground.</h2>
-          </div>
-        </div>
-        <div className="activity-strip">
-          {tiles.map((collection, index) => (
-            <Link
-              key={collection.handle}
-              className="activity-tile"
+              className="home-system-card"
               href={`/shop/${collection.handle}`}
+              key={collection.handle}
             >
               <Image
                 src={collection.heroImage.src}
@@ -313,17 +147,134 @@ export default async function HomePage() {
                 height={collection.heroImage.height}
                 sizes="(min-width: 820px) 34vw, 100vw"
               />
-              <span className="tile-index">
-                {String(index + 1).padStart(2, "0")}
-              </span>
-              <div className="activity-tile-content">
-                <p className="eyebrow">{collection.fieldCode}</p>
-                <h3 className="h3">{collection.title}</h3>
-                <p>{firstSentence(collection.description)}</p>
+              <div>
+                <span className="eyebrow">{collection.fieldCode}</span>
+                <h3>{collection.title}</h3>
+                <p>{collection.description}</p>
+                <span>Shop system →</span>
               </div>
             </Link>
           ))}
         </div>
+      </section>
+
+      {spotlight !== undefined && spotlightImage !== undefined ? (
+        <section className="home-spotlight shell section">
+          <div className="home-spotlight-media">
+            <Image
+              src={spotlightImage.src}
+              alt={spotlightImage.alt}
+              width={spotlightImage.width}
+              height={spotlightImage.height}
+              sizes="(min-width: 820px) 60vw, 100vw"
+            />
+          </div>
+          <div className="home-spotlight-copy">
+            <p className="eyebrow">Layer focus / {spotlight.category}</p>
+            <h2 className="h2">{spotlight.title}</h2>
+            <p className="lede">{spotlight.description}</p>
+            <ul>
+              {spotlight.specs.slice(0, 3).map((spec) => (
+                <li key={spec.label}>
+                  <span>{spec.label}</span>
+                  <strong>{spec.value}</strong>
+                </li>
+              ))}
+            </ul>
+            <Link
+              className="button button-primary"
+              href={`/products/${spotlight.handle}`}
+            >
+              Explore the layer
+            </Link>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="home-proof-band">
+        <div className="home-proof-copy">
+          <p className="eyebrow">Material standard</p>
+          <h2 className="h2">Fewer materials. Better understood.</h2>
+          <p>
+            Every fabric, foam, buckle, and compound is selected around useful
+            life, field repair, and performance you can actually feel.
+          </p>
+          <div className="home-proof-links">
+            <Link className="button button-light" href="/materials">
+              Explore materials
+            </Link>
+            <Link className="text-link" href="/about">
+              About Forward
+            </Link>
+          </div>
+        </div>
+        <Image
+          src={themeContent.standardBandImage.src}
+          alt={themeContent.standardBandImage.alt}
+          width={themeContent.standardBandImage.width}
+          height={themeContent.standardBandImage.height}
+          sizes="(min-width: 820px) 55vw, 100vw"
+        />
+      </section>
+
+      {pack !== undefined ? (
+        <section className="home-kit shell section">
+          <div className="home-kit-copy">
+            <p className="eyebrow">One-day kit</p>
+            <h2 className="h2">Carry the day, not the doubt.</h2>
+            <p>{pack.description}</p>
+            <Link className="text-link" href={`/products/${pack.handle}`}>
+              View {pack.title}
+            </Link>
+          </div>
+          <div className="home-kit-products">
+            {kitProducts.slice(0, 3).map(({ product, image }) => (
+              <Link href={`/products/${product.handle}`} key={product.handle}>
+                <Image
+                  src={image.src}
+                  alt={image.alt}
+                  width={image.width}
+                  height={image.height}
+                  sizes="(min-width: 820px) 20vw, 45vw"
+                />
+                <span className="home-kit-product-name">{product.title}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="home-service-grid shell section">
+        <article>
+          <p className="eyebrow">Repair, not replace</p>
+          <h2>Keep equipment in motion.</h2>
+          <p>
+            Product defects are repaired free. Wear, accidents, and hard-earned
+            damage are assessed honestly before work begins.
+          </p>
+          <Link className="text-link" href="/pages/field-repair">
+            Visit the repair desk
+          </Link>
+        </article>
+        {dispatch !== undefined ? (
+          <article className="home-dispatch-card">
+            <Image
+              src={dispatch.heroImage.src}
+              alt={dispatch.heroImage.alt}
+              width={dispatch.heroImage.width}
+              height={dispatch.heroImage.height}
+              sizes="(min-width: 820px) 45vw, 100vw"
+            />
+            <div>
+              <p className="eyebrow">Latest field note</p>
+              <h2>{dispatch.title}</h2>
+              <p>{dispatch.excerpt}</p>
+              <Link className="text-link" href={`/journal/${dispatch.handle}`}>
+                Read the dispatch
+              </Link>
+            </div>
+          </article>
+        ) : null}
       </section>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -243,7 +243,6 @@ export default async function HomePage() {
             <ProductCard
               key={product.handle}
               product={product}
-              index={String(index + 1).padStart(2, "0")}
               priority={index === 0}
             />
           ))}

--- a/src/app/products/[productHandle]/page.tsx
+++ b/src/app/products/[productHandle]/page.tsx
@@ -82,7 +82,7 @@ function ProductFieldRecord({ product }: { product: Product }) {
         <summary>Repair</summary>
         <p>{product.repair}</p>
         <p>
-          <Link className="text-link" href="/pages/repairs">
+          <Link className="text-link" href="/pages/field-repair">
             The repairs programme
           </Link>
         </p>

--- a/src/app/products/[productHandle]/product-detail.tsx
+++ b/src/app/products/[productHandle]/product-detail.tsx
@@ -129,7 +129,7 @@ function ProductDetailView({
             </Link>
           </p>
           <div className="product-kicker">
-            <span className="eyebrow">Plate {product.plate}</span>
+            <span className="eyebrow">Forward equipment</span>
             <span className="meta">{specBadge}</span>
           </div>
           <h1 className="product-title">{product.title}</h1>

--- a/src/app/products/[productHandle]/product-detail.tsx
+++ b/src/app/products/[productHandle]/product-detail.tsx
@@ -2,17 +2,20 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { type ReactNode, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { AddToCartForm } from "@/components/add-to-cart-form";
 import { cn } from "@/lib/cn";
 import { formatMoney } from "@/lib/storefront/format";
 import {
   COLORWAY_PARAM,
+  findExactVariant,
   galleryImages,
-  productColorwayHref,
-  resolveColorway,
+  optionParamKey,
+  productSelectionHref,
+  resolveProductSelection,
+  type ProductSelection,
 } from "@/lib/storefront/product-state";
 import type { Product, ProductColorway } from "@/lib/storefront/types";
 
@@ -21,29 +24,51 @@ interface ProductDetailProps {
   fieldRecord: ReactNode;
 }
 
-/**
- * Query-driven half of the PDP. Colorway selection lives in the browser via
- * `useSearchParams` so the route stays fully static (unknown handles become
- * real production 404s) while `?colorway=` deep links, swatch navigation, and
- * browser history keep working.
- */
+function requestedOptions(
+  product: Product,
+  params: URLSearchParams,
+): Readonly<Record<string, string | undefined>> {
+  return Object.fromEntries(
+    product.options.map((option) => [
+      option.name,
+      params.get(optionParamKey(option.name)) ?? undefined,
+    ]),
+  );
+}
+
 export function ProductDetail({ product, fieldRecord }: ProductDetailProps) {
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const requestedColorway = searchParams.get(COLORWAY_PARAM) ?? undefined;
+  const selection = resolveProductSelection(
+    product,
+    searchParams.get(COLORWAY_PARAM) ?? undefined,
+    requestedOptions(product, searchParams),
+  );
+  const canonicalHref = productSelectionHref(
+    product,
+    selection.colorway.id,
+    selection.selectedOptions,
+    searchParams,
+  );
+
+  useEffect(() => {
+    const query = searchParams.toString();
+    const current = `${pathname}${query === "" ? "" : `?${query}`}`;
+    if (current !== canonicalHref)
+      router.replace(canonicalHref, { scroll: false });
+  }, [canonicalHref, pathname, router, searchParams]);
+
   return (
     <ProductDetailView
       product={product}
-      colorway={resolveColorway(product, requestedColorway)}
+      selection={selection}
+      currentParams={searchParams}
       fieldRecord={fieldRecord}
     />
   );
 }
 
-/**
- * Suspense fallback for the static prerender: identical markup in the
- * canonical default-colorway state, so the served HTML is complete before
- * hydration resolves the query string.
- */
 export function ProductDetailFallback({
   product,
   fieldRecord,
@@ -51,19 +76,141 @@ export function ProductDetailFallback({
   return (
     <ProductDetailView
       product={product}
-      colorway={resolveColorway(product, undefined)}
+      selection={resolveProductSelection(product, undefined)}
+      currentParams={new URLSearchParams()}
       fieldRecord={fieldRecord}
     />
   );
 }
 
-/**
- * Canonical `.gallery` (source `app.js:281`): a lead frame spanning the tall
- * column plus selectable tiles, with the selected view marked by the
- * `.gallery-button.active` treatment. Images are the active colorway's four
- * approved frames. Keyed by colorway at the call site so selection resets on
- * colorway change.
- */
+function GalleryModal({
+  product,
+  colorway,
+  initialIndex,
+  onClose,
+}: {
+  product: Product;
+  colorway: ProductColorway;
+  initialIndex: number;
+  onClose(): void;
+}) {
+  const images = galleryImages(colorway);
+  const [index, setIndex] = useState(initialIndex);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return;
+    const previousOverflow = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    dialog.showModal();
+    return () => {
+      document.documentElement.style.overflow = previousOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        setIndex((current) => (current + 1) % images.length);
+      }
+      if (event.key === "ArrowLeft") {
+        setIndex((current) => (current - 1 + images.length) % images.length);
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [images.length, onClose]);
+
+  const image = images[index];
+  if (image === undefined) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="gallery-modal"
+      aria-label={`${product.title} image gallery`}
+      onClose={onClose}
+      onCancel={(event) => {
+        event.preventDefault();
+        dialogRef.current?.close();
+      }}
+    >
+      <div className="gallery-modal-bar">
+        <span>
+          {product.title} / {colorway.name}
+        </span>
+        <span>
+          {String(index + 1).padStart(2, "0")} /{" "}
+          {String(images.length).padStart(2, "0")}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close image gallery"
+        >
+          Close ×
+        </button>
+      </div>
+      <div className="gallery-modal-stage">
+        <Image
+          key={image.src}
+          src={image.src}
+          alt={image.alt}
+          width={image.width}
+          height={image.height}
+          sizes="100vw"
+          priority
+        />
+        <button
+          className="gallery-modal-arrow gallery-modal-prev"
+          type="button"
+          onClick={() =>
+            setIndex((current) => (current - 1 + images.length) % images.length)
+          }
+          aria-label="Previous image"
+        >
+          ←
+        </button>
+        <button
+          className="gallery-modal-arrow gallery-modal-next"
+          type="button"
+          onClick={() => setIndex((current) => (current + 1) % images.length)}
+          aria-label="Next image"
+        >
+          →
+        </button>
+      </div>
+      <fieldset className="gallery-modal-thumbs">
+        <legend className="sr-only">Choose gallery image</legend>
+        {images.map((entry, entryIndex) => (
+          <button
+            key={entry.src}
+            type="button"
+            className={cn(entryIndex === index && "active")}
+            aria-label={`View image ${entryIndex + 1}: ${entry.alt}`}
+            aria-pressed={entryIndex === index}
+            onClick={() => setIndex(entryIndex)}
+          >
+            <Image
+              src={entry.src}
+              alt=""
+              width={entry.width}
+              height={entry.height}
+              sizes="96px"
+            />
+          </button>
+        ))}
+      </fieldset>
+    </dialog>
+  );
+}
+
 function ProductGallery({
   product,
   colorway,
@@ -72,49 +219,68 @@ function ProductGallery({
   colorway: ProductColorway;
 }) {
   const gallery = galleryImages(colorway);
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [modalIndex, setModalIndex] = useState<number | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  function closeModal() {
+    document.documentElement.style.overflow = "";
+    setModalIndex(null);
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }
 
   return (
-    <section className="gallery" aria-label={`${product.title} gallery`}>
-      {gallery.map((image, index) => {
-        const active = index === selectedIndex;
-        return (
+    <>
+      <section className="gallery" aria-label={`${product.title} gallery`}>
+        {gallery.map((image, index) => (
           <button
             key={image.src}
             type="button"
-            className={cn("gallery-button", active && "active")}
-            aria-label={`Select view ${index + 1}: ${image.alt}`}
-            aria-pressed={active}
-            onClick={() => setSelectedIndex(index)}
+            className="gallery-button"
+            aria-label={`Zoom image ${index + 1}: ${image.alt}`}
+            onClick={(event) => {
+              triggerRef.current = event.currentTarget;
+              setModalIndex(index);
+            }}
           >
             <Image
               src={image.src}
-              alt={`${product.title} view ${index + 1}`}
+              alt={image.alt}
               width={image.width}
               height={image.height}
-              sizes={index === 0 ? "(min-width: 820px) 55vw, 100vw" : "30vw"}
+              sizes={index === 0 ? "(min-width: 820px) 55vw, 100vw" : "40vw"}
               priority={index === 0}
               loading={index === 0 ? undefined : "lazy"}
             />
+            <span className="gallery-zoom-label" aria-hidden="true">
+              Zoom +
+            </span>
           </button>
-        );
-      })}
-    </section>
+        ))}
+      </section>
+      {modalIndex !== null ? (
+        <GalleryModal
+          product={product}
+          colorway={colorway}
+          initialIndex={modalIndex}
+          onClose={closeModal}
+        />
+      ) : null}
+    </>
   );
 }
 
 interface ProductDetailViewProps extends ProductDetailProps {
-  colorway: ProductColorway;
+  selection: ProductSelection;
+  currentParams: URLSearchParams;
 }
 
-/**
- * Canonical `.pdp` grid and sticky `.product-panel` (source `app.js:279–288`).
- */
 function ProductDetailView({
   product,
-  colorway,
+  selection,
+  currentParams,
   fieldRecord,
 }: ProductDetailViewProps) {
+  const { colorway } = selection;
   const specBadge = product.specs[0]?.value ?? product.category;
 
   return (
@@ -133,29 +299,35 @@ function ProductDetailView({
             <span className="meta">{specBadge}</span>
           </div>
           <h1 className="product-title">{product.title}</h1>
-          <strong>{formatMoney(product.price)}</strong>
+          <strong>{formatMoney(selection.variant.price)}</strong>
           <p className="product-intro">{product.description}</p>
 
-          {/* Colorway selection stays a set of canonical deep links. */}
           <div className="option-group">
             <div className="option-label">
               <span>Color</span>
               <span>{colorway.name}</span>
             </div>
-            {/* Each link carries its own colorway name and selected state. */}
             <div className="option-row">
               {product.colorways.map((entry) => {
+                const next = resolveProductSelection(
+                  product,
+                  entry.id,
+                  selection.selectedOptions,
+                );
                 const selected = entry.id === colorway.id;
                 return (
                   <Link
                     key={entry.id}
                     className={cn("option-chip", selected && "selected")}
-                    href={productColorwayHref(product, entry.id)}
+                    href={productSelectionHref(
+                      product,
+                      next.colorway.id,
+                      next.selectedOptions,
+                      currentParams,
+                    )}
                     scroll={false}
+                    aria-label={`${entry.name} colorway${selected ? " (selected)" : ""}`}
                     aria-current={selected ? "true" : undefined}
-                    aria-label={`${entry.name} colorway${
-                      selected ? " (selected)" : ""
-                    }`}
                   >
                     <span
                       aria-hidden="true"
@@ -169,12 +341,68 @@ function ProductDetailView({
             </div>
           </div>
 
-          <AddToCartForm
-            key={colorway.id}
-            product={product}
-            colorway={colorway}
-          />
+          {product.options.map((option) => (
+            <div className="option-group" key={option.name}>
+              <div className="option-label">
+                <span>{option.name}</span>
+                <span>{selection.selectedOptions[option.name]}</span>
+              </div>
+              <div className="option-row">
+                {option.values.map((value) => {
+                  const nextOptions = {
+                    ...selection.selectedOptions,
+                    [option.name]: value,
+                  };
+                  const exact = findExactVariant(
+                    product,
+                    colorway.id,
+                    nextOptions,
+                  );
+                  const selected =
+                    selection.selectedOptions[option.name] === value;
+                  if (exact === undefined || !exact.availableForSale) {
+                    return (
+                      <span
+                        key={value}
+                        className={cn(
+                          "option-chip unavailable",
+                          selected && "selected",
+                        )}
+                        aria-disabled="true"
+                        aria-current={selected ? "true" : undefined}
+                        title={`${value} is unavailable`}
+                      >
+                        {value}
+                        <span className="sr-only"> (sold out)</span>
+                      </span>
+                    );
+                  }
+                  return (
+                    <Link
+                      key={value}
+                      className={cn("option-chip", selected && "selected")}
+                      href={productSelectionHref(
+                        product,
+                        colorway.id,
+                        nextOptions,
+                        currentParams,
+                      )}
+                      scroll={false}
+                      aria-current={selected ? "true" : undefined}
+                    >
+                      {value}
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
 
+          <AddToCartForm
+            key={selection.variant.id}
+            product={product}
+            selection={selection}
+          />
           {fieldRecord}
         </div>
       </section>

--- a/src/app/products/[productHandle]/product-detail.tsx
+++ b/src/app/products/[productHandle]/product-detail.tsx
@@ -223,7 +223,6 @@ function ProductGallery({
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   function closeModal() {
-    document.documentElement.style.overflow = "";
     setModalIndex(null);
     requestAnimationFrame(() => triggerRef.current?.focus());
   }

--- a/src/app/shop/[collectionHandle]/page.tsx
+++ b/src/app/shop/[collectionHandle]/page.tsx
@@ -104,9 +104,7 @@ export default async function CollectionPage({ params }: CollectionPageProps) {
             <ul className="kit-list">
               {products.map((product) => (
                 <li key={product.handle}>
-                  <span>
-                    {product.plate} / {product.title}
-                  </span>
+                  <span>{product.title}</span>
                   <span>{product.category}</span>
                 </li>
               ))}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -232,6 +232,7 @@ export default async function ShopPage({ searchParams }: ShopPageProps) {
       <div className="shell plp-layout">
         <FilterSidebar groups={filterGroups} idPrefix="desktop" />
         <section aria-label="Products">
+          <h2 className="sr-only">Products</h2>
           {/* Mobile filters: the canonical drawer is a JS prototype, so
               Forward uses a no-JavaScript disclosure instead. */}
           <details className="filter-disclosure">
@@ -251,10 +252,10 @@ export default async function ShopPage({ searchParams }: ShopPageProps) {
           ) : (
             <div className="empty-state">
               <div className="empty-state-inner">
-                <p className="eyebrow">No matching plates</p>
+                <p className="eyebrow">No matching products</p>
                 <h2 className="h3">Nothing in this drawer.</h2>
                 <p className="muted">
-                  No products match this filter. The full catalog is three
+                  No products match this filter. The full catalog is nine
                   products deep — try widening the view.
                 </p>
                 <Link className="button button-primary" href="/shop">

--- a/src/app/site-header.css
+++ b/src/app/site-header.css
@@ -25,9 +25,9 @@
   border-inline-start: 1px solid var(--line);
   background: transparent;
   color: inherit;
-  font-family: var(--mono);
-  font-size: 9px;
-  font-weight: 500;
+  font-family: var(--ui);
+  font-size: 10px;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
@@ -85,7 +85,7 @@
   align-items: center;
   justify-content: space-between;
   color: var(--muted);
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -98,12 +98,12 @@
 }
 
 .field-index-number {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 10px;
 }
 
 .field-index-arrow {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 15px;
 }
 
@@ -203,7 +203,7 @@
 }
 
 .field-index-visual figcaption span {
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
   letter-spacing: 0.1em;
 }
@@ -263,7 +263,7 @@
 .field-mobile-index nav a > span {
   grid-row: 1 / span 2;
   color: #8fa095;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 9px;
 }
 
@@ -282,7 +282,7 @@
 .field-mobile-note {
   margin: 22px 0 0;
   color: #8fa095;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -308,7 +308,7 @@
 .field-mobile-secondary a > span:first-child,
 .field-mobile-secondary a i {
   color: #8fa095;
-  font-family: var(--mono);
+  font-family: var(--ui);
   font-size: 8px;
   font-style: normal;
 }

--- a/src/components/add-to-cart-form.tsx
+++ b/src/components/add-to-cart-form.tsx
@@ -22,14 +22,10 @@ interface AddToCartFormProps {
   selection: ProductSelection;
 }
 
-function selectedSize(selection: ProductSelection): string | undefined {
-  return selection.selectedOptions.Size;
-}
-
 function DemoAddToCartForm({ product, selection }: AddToCartFormProps) {
   const [quantity, setQuantity] = useState(1);
   const [status, setStatus] = useState("");
-  const size = selectedSize(selection);
+  const size = selection.selectedOptions.Size;
 
   function handleAdd() {
     if (!selection.variant.availableForSale) return;
@@ -40,7 +36,6 @@ function DemoAddToCartForm({ product, selection }: AddToCartFormProps) {
       title: product.title,
       colorwayId: selection.colorway.id,
       colorwayName: selection.colorway.name,
-      size,
       selectedOptions: selection.selectedOptions,
       quantity,
       unitPrice: selection.variant.price,

--- a/src/components/add-to-cart-form.tsx
+++ b/src/components/add-to-cart-form.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useState } from "react";
 
-import { cn } from "@/lib/cn";
 import {
   ShopifyProductProvider,
   toHydrogenProductInput,
@@ -12,48 +11,48 @@ import {
 import { lineKey, MAX_LINE_QUANTITY } from "@/lib/demo-cart/cart-logic";
 import { addCartLine } from "@/lib/demo-cart/store";
 import { formatMoney } from "@/lib/storefront/format";
-import { productColorwayHref } from "@/lib/storefront/product-state";
-import type { Product, ProductColorway } from "@/lib/storefront/types";
+import {
+  productSelectionHref,
+  type ProductSelection,
+} from "@/lib/storefront/product-state";
+import type { Product } from "@/lib/storefront/types";
 
 interface AddToCartFormProps {
   product: Product;
-  colorway: ProductColorway;
+  selection: ProductSelection;
 }
 
-/**
- * Canonical size `.option-group`, `.product-actions`, and `.add-feedback`
- * (source `app.js:284–285`).
- *
- * Behavior stays Forward-owned: the canonical prototype adds to a global
- * object and opens a fake drawer, while this writes to the browser-local demo
- * cart with the existing quantity limits, line key, and live-region status.
- */
-function DemoAddToCartForm({ product, colorway }: AddToCartFormProps) {
-  const sizeOption = product.options[0];
-  const [size, setSize] = useState<string | undefined>(undefined);
+function selectedSize(selection: ProductSelection): string | undefined {
+  return selection.selectedOptions.Size;
+}
+
+function DemoAddToCartForm({ product, selection }: AddToCartFormProps) {
   const [quantity, setQuantity] = useState(1);
   const [status, setStatus] = useState("");
-  const groupId = useId();
+  const size = selectedSize(selection);
 
   function handleAdd() {
-    if (sizeOption !== undefined && size === undefined) {
-      setStatus(`Choose a ${sizeOption.name.toLowerCase()} first.`);
-      return;
-    }
+    if (!selection.variant.availableForSale) return;
     addCartLine({
-      key: lineKey(product.handle, colorway.id, size),
+      key: lineKey(product.handle, selection.variant.id),
+      variantId: selection.variant.id,
       productHandle: product.handle,
       title: product.title,
-      colorwayId: colorway.id,
-      colorwayName: colorway.name,
+      colorwayId: selection.colorway.id,
+      colorwayName: selection.colorway.name,
       size,
+      selectedOptions: selection.selectedOptions,
       quantity,
-      unitPrice: product.price,
-      image: colorway.images.primary,
-      href: productColorwayHref(product, colorway.id),
+      unitPrice: selection.variant.price,
+      image: selection.colorway.images.primary,
+      href: productSelectionHref(
+        product,
+        selection.colorway.id,
+        selection.selectedOptions,
+      ),
     });
     setStatus(
-      `Added ${quantity} × ${product.title} (${colorway.name}${
+      `Added ${quantity} × ${product.title} (${selection.colorway.name}${
         size !== undefined ? `, ${size}` : ""
       }) to the demo cart.`,
     );
@@ -61,45 +60,12 @@ function DemoAddToCartForm({ product, colorway }: AddToCartFormProps) {
 
   return (
     <>
-      {sizeOption !== undefined ? (
-        <fieldset className="option-group">
-          <legend className="sr-only">{sizeOption.name}</legend>
-          <div className="option-label">
-            <span>{sizeOption.name}</span>
-            <span>{size ?? "Select"}</span>
-          </div>
-          <div className="option-row">
-            {sizeOption.values.map((value) => {
-              const selected = size === value;
-              return (
-                <label
-                  key={value}
-                  className={cn("option-chip", selected && "selected")}
-                >
-                  <input
-                    className="sr-only"
-                    type="radio"
-                    name={`${groupId}-size`}
-                    value={value}
-                    checked={selected}
-                    onChange={() => {
-                      setSize(value);
-                      setStatus("");
-                    }}
-                  />
-                  {value}
-                </label>
-              );
-            })}
-          </div>
-        </fieldset>
-      ) : null}
-
       <div className="product-actions">
         <div className="quantity">
           <button
             type="button"
             aria-label="Decrease quantity"
+            disabled={quantity <= 1}
             onClick={() => setQuantity((current) => Math.max(1, current - 1))}
           >
             −
@@ -110,6 +76,7 @@ function DemoAddToCartForm({ product, colorway }: AddToCartFormProps) {
           <button
             type="button"
             aria-label="Increase quantity"
+            disabled={quantity >= MAX_LINE_QUANTITY}
             onClick={() =>
               setQuantity((current) => Math.min(MAX_LINE_QUANTITY, current + 1))
             }
@@ -118,13 +85,14 @@ function DemoAddToCartForm({ product, colorway }: AddToCartFormProps) {
           </button>
         </div>
         <button
-          className="button button-signal"
+          className="button button-signal product-atc"
           type="button"
+          disabled={!selection.variant.availableForSale}
           onClick={handleAdd}
         >
-          Add to cart ·{" "}
+          {selection.variant.availableForSale ? "Add to cart" : "Sold out"} ·{" "}
           {formatMoney({
-            amount: product.price.amount * quantity,
+            amount: selection.variant.price.amount * quantity,
             currencyCode: "USD",
           })}
         </button>
@@ -140,49 +108,18 @@ function DemoAddToCartForm({ product, colorway }: AddToCartFormProps) {
   );
 }
 
-function ShopifyAddToCartForm({ product }: AddToCartFormProps) {
-  const { formProps, options, pending, register, selectedVariant } =
+function ShopifyAddToCartForm({ selection }: AddToCartFormProps) {
+  const { formProps, pending, register, selectedVariant } =
     useShopifyProductForm();
   const [quantity, setQuantity] = useState(1);
   const selectedPrice = Number(
-    selectedVariant?.price.amount ?? product.price.amount,
+    selectedVariant?.price.amount ?? selection.variant.price.amount,
   );
 
   return (
     <form {...formProps()}>
       <input type="hidden" {...register("merchandiseId", {})} />
       <input type="hidden" {...register("quantity", { value: quantity })} />
-      {options.map((option) => {
-        if (option.name.toLowerCase() === "color") return null;
-        const selected = option.values.find((value) => value.selected)?.name;
-        return (
-          <fieldset className="option-group" key={option.name}>
-            <legend className="sr-only">{option.name}</legend>
-            <div className="option-label">
-              <span>{option.name}</span>
-              <span>{selected ?? "Unavailable"}</span>
-            </div>
-            <div className="option-row">
-              {option.values.map((value) => (
-                <button
-                  {...register("optionValue", {
-                    optionName: option.name,
-                    value: value.name,
-                  })}
-                  aria-pressed={value.selected}
-                  className={cn("option-chip", value.selected && "selected")}
-                  disabled={!value.available}
-                  key={value.name}
-                  type="button"
-                >
-                  {value.name}
-                </button>
-              ))}
-            </div>
-          </fieldset>
-        );
-      })}
-
       <div className="product-actions">
         <div className="quantity">
           <button
@@ -209,7 +146,7 @@ function ShopifyAddToCartForm({ product }: AddToCartFormProps) {
         </div>
         <button
           {...register("addToCart", {})}
-          className="button button-signal"
+          className="button button-signal product-atc"
           disabled={
             pending ||
             selectedVariant === null ||
@@ -237,7 +174,11 @@ function ShopifyAddToCartForm({ product }: AddToCartFormProps) {
 export function AddToCartForm(props: AddToCartFormProps) {
   return useShopifyCartMode() ? (
     <ShopifyProductProvider
-      product={toHydrogenProductInput(props.product, props.colorway.id)}
+      product={toHydrogenProductInput(
+        props.product,
+        props.selection.colorway.id,
+        props.selection.variant.id,
+      )}
     >
       <ShopifyAddToCartForm {...props} />
     </ShopifyProductProvider>

--- a/src/components/cart-view.tsx
+++ b/src/components/cart-view.tsx
@@ -102,8 +102,10 @@ export function CartView({ seedLines }: CartViewProps) {
                     <Link href={line.href}>{line.title}</Link>
                   </h2>
                   <p className="muted">
-                    {line.colorwayName}
-                    {line.size !== undefined ? ` · ${line.size}` : ""}
+                    {[
+                      line.colorwayName,
+                      ...Object.values(line.selectedOptions),
+                    ].join(" · ")}
                   </p>
                   <div className="line-controls">
                     {/* Each control names its own line, so the canonical

--- a/src/components/field-index-header.tsx
+++ b/src/components/field-index-header.tsx
@@ -276,7 +276,7 @@ export function FieldIndexHeader({
       );
     const backgroundElements = Array.from(
       document.querySelectorAll<HTMLElement>(
-        ".skip-link, .announcement, .field-header, .coordinate-spine, #main-content, footer",
+        ".skip-link, .announcement, .field-header, #main-content, footer",
       ),
     );
     const previousInertStates = backgroundElements.map((element) => ({
@@ -443,12 +443,6 @@ export function FieldIndexHeader({
           />
         ) : null}
       </header>
-      <aside className="coordinate-spine" aria-hidden="true">
-        <span>N 54° 27′</span>
-        <b>FORWARD</b>
-        <span>W 3° 05′</span>
-      </aside>
-
       {mobileOpen ? (
         <aside
           ref={mobilePanelRef}

--- a/src/components/product-card.tsx
+++ b/src/components/product-card.tsx
@@ -13,8 +13,6 @@ import type { Product } from "@/lib/storefront/types";
 
 interface ProductCardProps {
   product: Product;
-  /** Overrides the oversized `.product-number` (defaults to the plate). */
-  index?: string;
   priority?: boolean;
 }
 
@@ -28,14 +26,13 @@ interface ProductCardProps {
  * real controls: native radios in 44×44 targets, a visible selected ring and
  * name, and a deep link that retargets to the selected colorway.
  */
-export function ProductCard({ product, index, priority }: ProductCardProps) {
+export function ProductCard({ product, priority }: ProductCardProps) {
   const [activeColorwayId, setActiveColorwayId] = useState(
     product.colorways[0]?.id ?? "",
   );
   const swatchGroupName = useId();
   const activeColorway = resolveColorway(product, activeColorwayId);
   const href = productColorwayHref(product, activeColorway.id);
-  const cardIndex = index ?? product.plate;
   const badge = product.activities[0];
 
   return (
@@ -53,9 +50,6 @@ export function ProductCard({ product, index, priority }: ProductCardProps) {
           sizes="(min-width: 1100px) 34vw, (min-width: 560px) 45vw, 90vw"
           priority={priority}
         />
-        <span className="product-number" aria-hidden="true">
-          {cardIndex}
-        </span>
         {badge !== undefined ? (
           <span className="product-badge">{badge}</span>
         ) : null}

--- a/src/components/product-card.tsx
+++ b/src/components/product-card.tsx
@@ -18,9 +18,8 @@ interface ProductCardProps {
 
 /**
  * Canonical product card. Source `app.js:87–107` — one card hierarchy shared
- * by the Home runway, PLP, collection, search, and related-product grids. Grid
- * span, image ratio, and stagger come entirely from the `.product-runway` /
- * `.plp-grid` nth-child rules in `canonical-source.css`.
+ * by Home, PLP, collection, search, and related-product grids. Parent surfaces
+ * own grid geometry while the card keeps one consistent 4:5 image treatment.
  *
  * The canonical `.swatches` row is inert decoration. Forward's swatches are
  * real controls: native radios in 44×44 targets, a visible selected ring and

--- a/src/lib/cart/shopify-cart-react.tsx
+++ b/src/lib/cart/shopify-cart-react.tsx
@@ -54,6 +54,7 @@ export function useShopifyCartMode(): boolean {
 export function toHydrogenProductInput(
   product: Product,
   colorwayId: string,
+  selectedVariantId?: string,
 ): ProductInput {
   const colorway = product.colorways.find(({ id }) => id === colorwayId);
   if (colorway === undefined) {
@@ -77,7 +78,10 @@ export function toHydrogenProductInput(
       },
     }));
   const selectedOrFirstAvailableVariant =
-    variants.find((variant) => variant.availableForSale) ?? variants[0] ?? null;
+    variants.find((variant) => variant.id === selectedVariantId) ??
+    variants.find((variant) => variant.availableForSale) ??
+    variants[0] ??
+    null;
   const options = [
     {
       name: "Color",

--- a/src/lib/demo-cart/cart-logic.ts
+++ b/src/lib/demo-cart/cart-logic.ts
@@ -15,13 +15,15 @@ export const MAX_LINE_QUANTITY = 9;
 const HANDLE_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export interface DemoCartLine {
-  /** Stable identity for a product + colorway + size combination. */
+  /** Stable identity for one exact catalog variant. */
   key: string;
+  variantId: string;
   productHandle: string;
   title: string;
   colorwayId: string;
   colorwayName: string;
   size?: string;
+  selectedOptions: Readonly<Record<string, string>>;
   quantity: number;
   unitPrice: Money;
   image: StorefrontImage;
@@ -29,12 +31,8 @@ export interface DemoCartLine {
   href: string;
 }
 
-export function lineKey(
-  productHandle: string,
-  colorwayId: string,
-  size?: string,
-): string {
-  return [productHandle, colorwayId, size ?? ""].join("::");
+export function lineKey(productHandle: string, variantId: string): string {
+  return [productHandle, variantId].join("::");
 }
 
 function clampQuantity(quantity: number): number {
@@ -127,11 +125,40 @@ function isCanonicalProductHref(
   productHandle: string,
   colorwayId: string,
 ): boolean {
-  const base = `/products/${productHandle}`;
-  return (
-    href === base ||
-    href === `${base}?colorway=${encodeURIComponent(colorwayId)}`
-  );
+  try {
+    const url = new URL(href, "https://forward.local");
+    return (
+      url.origin === "https://forward.local" &&
+      url.pathname === `/products/${productHandle}` &&
+      (url.searchParams.get("colorway") === null ||
+        url.searchParams.get("colorway") === colorwayId)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeSelectedOptions(
+  value: unknown,
+): Readonly<Record<string, string>> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const entries = Object.entries(value);
+  if (
+    entries.length > 8 ||
+    entries.some(
+      ([name, option]) =>
+        name.trim().length === 0 ||
+        name.length > 80 ||
+        typeof option !== "string" ||
+        option.trim().length === 0 ||
+        option.length > 120,
+    )
+  ) {
+    return null;
+  }
+  return Object.fromEntries(entries) as Readonly<Record<string, string>>;
 }
 
 /** Validates lines revived from storage; malformed entries are dropped. */
@@ -148,10 +175,13 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
     const line = entry as Record<string, unknown>;
     if (
       typeof line.key !== "string" ||
+      typeof line.variantId !== "string" ||
+      line.variantId.trim().length === 0 ||
       typeof line.productHandle !== "string" ||
       typeof line.title !== "string" ||
       typeof line.colorwayId !== "string" ||
       typeof line.colorwayName !== "string" ||
+      (line.size !== undefined && typeof line.size !== "string") ||
       typeof line.quantity !== "number" ||
       typeof line.href !== "string" ||
       seen.has(line.key)
@@ -161,6 +191,7 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
     const unitPrice = line.unitPrice as Record<string, unknown> | undefined;
     const image = line.image as Record<string, unknown> | undefined;
     const size = typeof line.size === "string" ? line.size : undefined;
+    const selectedOptions = sanitizeSelectedOptions(line.selectedOptions);
     if (
       unitPrice === undefined ||
       typeof unitPrice.amount !== "number" ||
@@ -168,6 +199,7 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
       unitPrice.amount < 0 ||
       unitPrice.currencyCode !== "USD" ||
       image === undefined ||
+      selectedOptions === null ||
       typeof image.src !== "string" ||
       /* Static mode stores local catalog paths; Shopify mode stores owned CDN
          media URLs. Anything else is dropped on revive. */
@@ -180,7 +212,7 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
       line.colorwayName.trim().length === 0 ||
       !HANDLE_PATTERN.test(line.productHandle) ||
       !HANDLE_PATTERN.test(line.colorwayId) ||
-      line.key !== lineKey(line.productHandle, line.colorwayId, size) ||
+      line.key !== lineKey(line.productHandle, line.variantId) ||
       !isCanonicalProductHref(line.href, line.productHandle, line.colorwayId)
     ) {
       continue;
@@ -188,11 +220,13 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
     seen.add(line.key);
     lines.push({
       key: line.key,
+      variantId: line.variantId,
       productHandle: line.productHandle,
       title: line.title,
       colorwayId: line.colorwayId,
       colorwayName: line.colorwayName,
       size,
+      selectedOptions,
       quantity: clampQuantity(line.quantity),
       unitPrice: { amount: unitPrice.amount, currencyCode: "USD" },
       image: {

--- a/src/lib/demo-cart/cart-logic.ts
+++ b/src/lib/demo-cart/cart-logic.ts
@@ -22,7 +22,6 @@ export interface DemoCartLine {
   title: string;
   colorwayId: string;
   colorwayName: string;
-  size?: string;
   selectedOptions: Readonly<Record<string, string>>;
   quantity: number;
   unitPrice: Money;
@@ -181,7 +180,6 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
       typeof line.title !== "string" ||
       typeof line.colorwayId !== "string" ||
       typeof line.colorwayName !== "string" ||
-      (line.size !== undefined && typeof line.size !== "string") ||
       typeof line.quantity !== "number" ||
       typeof line.href !== "string" ||
       seen.has(line.key)
@@ -190,7 +188,6 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
     }
     const unitPrice = line.unitPrice as Record<string, unknown> | undefined;
     const image = line.image as Record<string, unknown> | undefined;
-    const size = typeof line.size === "string" ? line.size : undefined;
     const selectedOptions = sanitizeSelectedOptions(line.selectedOptions);
     if (
       unitPrice === undefined ||
@@ -225,7 +222,6 @@ export function sanitizeLines(value: unknown): readonly DemoCartLine[] {
       title: line.title,
       colorwayId: line.colorwayId,
       colorwayName: line.colorwayName,
-      size,
       selectedOptions,
       quantity: clampQuantity(line.quantity),
       unitPrice: { amount: unitPrice.amount, currencyCode: "USD" },

--- a/src/lib/routes/route-contract.ts
+++ b/src/lib/routes/route-contract.ts
@@ -114,6 +114,24 @@ export const CANONICAL_ROUTES: readonly RouteContractEntry[] = [
     smoke: { path: "/journal", expectedStatus: 200 },
   },
   {
+    pattern: "/about",
+    label: "About Forward custom page",
+    category: "content",
+    smoke: { path: "/about", expectedStatus: 200 },
+  },
+  {
+    pattern: "/materials",
+    label: "Materials custom page",
+    category: "content",
+    smoke: { path: "/materials", expectedStatus: 200 },
+  },
+  {
+    pattern: "/field-testing",
+    label: "Field testing custom page",
+    category: "content",
+    smoke: { path: "/field-testing", expectedStatus: 200 },
+  },
+  {
     pattern: "/journal/[articleHandle]",
     label: "Journal article",
     category: "editorial",

--- a/src/lib/routes/route-contract.ts
+++ b/src/lib/routes/route-contract.ts
@@ -56,16 +56,10 @@ export const SMOKE_FIXTURES = {
     "talus-trail-shoe",
   ],
   collectionHandle: "outerwear",
-  articleHandle: "walking-the-long-light",
-  pageHandle: "about-forward",
-  policyHandle: "shipping-policy",
-  orderId: "1001",
-} as const;
-
-export const LIVE_CONTENT_SMOKE_FIXTURES = {
   articleHandle: "layering-for-moving-weather",
   pageHandle: "about-forward",
   policyHandle: "shipping-policy",
+  orderId: "1001",
 } as const;
 
 const PRIMARY_PRODUCT_FIXTURE = SMOKE_FIXTURES.productHandles[0];

--- a/src/lib/storefront/catalog-presentation.ts
+++ b/src/lib/storefront/catalog-presentation.ts
@@ -1,58 +1,39 @@
-/**
- * Theme-owned catalog presentation profile.
- *
- * Shopify owns product identity, copy, price, options, media, and the `forward`
- * metafields. It does not currently own the editorial framing the approved
- * canonical source port depends on, so those fields stay here, keyed by the
- * three approved product handles.
- *
- * This is deliberately NOT a copy of the static `Product` fixture: it may only
- * carry fields Shopify does not own. Everything else must come from the live
- * adapter (or, in static mode, from `fixtures/products.ts`).
- *
- * Colorway IDs are canonical and load-bearing: PDP/PLP deep links
- * (`?colorway=charcoal`), the demo cart seed, and the demo order fixtures all
- * reference them. Mapping full Shopify Color labels onto these IDs is what
- * keeps those references valid.
- */
+/** Theme-owned presentation fields keyed by the exact managed catalog handles. */
 
 import type { ProductCategory } from "./types";
 
 export interface PresentationColorway {
-  /** Canonical normalized colorway id used by deep links and demo state. */
   id: string;
-  /** Solid swatch color; presentation-owned until Shopify swatches exist. */
   swatchColor: string;
 }
 
 export interface CatalogPresentationProfile {
   handle: string;
-  /** Canonical plate number used by the editorial framing. */
   plate: string;
   category: ProductCategory;
-  /** Approved activity labels backing the current PLP filters. */
   activities: readonly string[];
-  /** Concise subtitle; the live description is not an equivalent field. */
   subtitle: string;
-  /** Repair-program copy. */
   repair: string;
-  /** Related-product handle order. */
   relatedHandles: readonly string[];
-  /** Exact Shopify `Color` option label -> canonical colorway identity. */
   colorways: Readonly<Record<string, PresentationColorway>>;
 }
 
-const CHARCOAL_SWATCH = "#3b403f";
+const CHARCOAL = "#3b403f";
+const MOSS = "#59654b";
+const CLAYSTONE = "#a9705a";
+const DUNE = "#c4ad83";
+const LIMESTONE = "#cfc8b8";
 
-/**
- * Canonical catalog order. Storefront API title/created ordering is not
- * authoritative for the approved presentation, so the adapter re-orders live
- * products to match this list.
- */
 export const CANONICAL_PRODUCT_HANDLES = [
   "weatherline-shell",
+  "traverse-grid-fleece",
+  "drift-insulated-vest",
   "ridge-30-field-pack",
+  "approach-18-day-pack",
+  "waypoint-sling-6",
   "talus-trail-shoe",
+  "scree-approach-shoe",
+  "camp-recovery-clog",
 ] as const;
 
 export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[] =
@@ -65,53 +46,130 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
       subtitle: "Three-layer waterproof shell for shifting coastal weather.",
       repair:
         "Field-repair small punctures with tenacious tape; our repairs program handles delaminations, zip replacements, and re-taping for the life of the garment.",
-      relatedHandles: ["ridge-30-field-pack", "talus-trail-shoe"],
+      relatedHandles: ["traverse-grid-fleece", "ridge-30-field-pack"],
       colorways: {
-        "Charcoal / Moss": { id: "charcoal", swatchColor: CHARCOAL_SWATCH },
-        "Claystone / Charcoal": { id: "claystone", swatchColor: "#a9705a" },
+        "Charcoal / Moss": { id: "charcoal", swatchColor: CHARCOAL },
+        "Claystone / Charcoal": { id: "claystone", swatchColor: CLAYSTONE },
+      },
+    },
+    {
+      handle: "traverse-grid-fleece",
+      plate: "02",
+      category: "shells",
+      activities: ["trail", "alpine", "travel"],
+      subtitle: "Breathable grid fleece for fast temperature changes.",
+      repair:
+        "Cuffs, pocket openings, and small tears can be reinforced through the Forward repair program.",
+      relatedHandles: ["weatherline-shell", "drift-insulated-vest"],
+      colorways: {
+        "Moss / Charcoal": { id: "moss-charcoal", swatchColor: MOSS },
+        "Claystone / Bone": { id: "claystone-bone", swatchColor: CLAYSTONE },
+      },
+    },
+    {
+      handle: "drift-insulated-vest",
+      plate: "03",
+      category: "shells",
+      activities: ["alpine", "camp", "travel"],
+      subtitle: "Packable synthetic warmth for exposed starts and stops.",
+      repair:
+        "Shell tears, pocket damage, and insulation migration are assessed and repaired where construction allows.",
+      relatedHandles: ["traverse-grid-fleece", "weatherline-shell"],
+      colorways: {
+        "Charcoal / Signal": { id: "charcoal-signal", swatchColor: CHARCOAL },
+        "Dune / Moss": { id: "dune-moss", swatchColor: DUNE },
       },
     },
     {
       handle: "ridge-30-field-pack",
-      plate: "02",
+      plate: "04",
       category: "packs",
       activities: ["alpine", "trail"],
       subtitle: "A 30-liter pack built for long days above the treeline.",
       repair:
         "Buckles, straps, and stays are standard parts we stock for replacement. Torn panels and blown seams go through the repairs program rather than the landfill.",
-      relatedHandles: ["weatherline-shell", "talus-trail-shoe"],
+      relatedHandles: ["approach-18-day-pack", "weatherline-shell"],
       colorways: {
-        "Charcoal / Moss / Tan": {
-          id: "charcoal",
-          swatchColor: CHARCOAL_SWATCH,
-        },
-        "Dune / Charcoal": { id: "dune", swatchColor: "#c4ad83" },
+        "Charcoal / Moss / Tan": { id: "charcoal", swatchColor: CHARCOAL },
+        "Dune / Charcoal": { id: "dune", swatchColor: DUNE },
+      },
+    },
+    {
+      handle: "approach-18-day-pack",
+      plate: "05",
+      category: "packs",
+      activities: ["alpine", "trail", "travel"],
+      subtitle: "Close-body 18-liter carry for short technical days.",
+      repair:
+        "Replaceable hardware and repairable seams keep the pack in service after hard use.",
+      relatedHandles: ["ridge-30-field-pack", "scree-approach-shoe"],
+      colorways: {
+        "Moss / Charcoal": { id: "moss-charcoal", swatchColor: MOSS },
+        "Claystone / Dune": { id: "claystone-dune", swatchColor: CLAYSTONE },
+      },
+    },
+    {
+      handle: "waypoint-sling-6",
+      plate: "06",
+      category: "packs",
+      activities: ["travel", "camp"],
+      subtitle: "Compact six-liter carry with fast, one-handed access.",
+      repair:
+        "Straps, buckles, zip pulls, and accessible seams can be replaced or reinforced.",
+      relatedHandles: ["approach-18-day-pack", "camp-recovery-clog"],
+      colorways: {
+        "Charcoal / Signal": { id: "charcoal-signal", swatchColor: CHARCOAL },
+        "Dune / Moss": { id: "dune-moss", swatchColor: DUNE },
       },
     },
     {
       handle: "talus-trail-shoe",
-      plate: "03",
+      plate: "07",
       category: "footwear",
       activities: ["trail", "camp"],
       subtitle: "Grippy, stable footwear for scree, roots, and river rock.",
       repair:
         "Delaminated outsoles within reason are re-bonded through the repairs program. Worn laces and insoles are standard replaceable parts.",
-      relatedHandles: ["ridge-30-field-pack", "weatherline-shell"],
+      relatedHandles: ["scree-approach-shoe", "ridge-30-field-pack"],
       colorways: {
-        "Charcoal / Moss / Gum": {
-          id: "charcoal",
-          swatchColor: CHARCOAL_SWATCH,
-        },
-        "Limestone / Clay / Moss": { id: "limestone", swatchColor: "#cfc8b8" },
+        "Charcoal / Moss / Gum": { id: "charcoal", swatchColor: CHARCOAL },
+        "Limestone / Clay / Moss": { id: "limestone", swatchColor: LIMESTONE },
       },
     },
-  ] as const;
+    {
+      handle: "scree-approach-shoe",
+      plate: "08",
+      category: "footwear",
+      activities: ["alpine", "trail"],
+      subtitle: "Precise low-profile footwear for rock and mixed approaches.",
+      repair:
+        "Laces and footbeds are replaceable; repairable bonding failures are assessed by the repair desk.",
+      relatedHandles: ["talus-trail-shoe", "approach-18-day-pack"],
+      colorways: {
+        "Charcoal / Gum": { id: "charcoal-gum", swatchColor: CHARCOAL },
+        "Limestone / Moss": { id: "limestone-moss", swatchColor: LIMESTONE },
+      },
+    },
+    {
+      handle: "camp-recovery-clog",
+      plate: "09",
+      category: "footwear",
+      activities: ["camp", "travel"],
+      subtitle: "Easy-on recovery footwear with durable wet-ground traction.",
+      repair:
+        "Replaceable straps and repairable bonding failures are handled through the repair desk.",
+      relatedHandles: ["talus-trail-shoe", "waypoint-sling-6"],
+      colorways: {
+        "Charcoal / Moss": { id: "charcoal-moss", swatchColor: CHARCOAL },
+        "Dune / Claystone": { id: "dune-claystone", swatchColor: DUNE },
+      },
+    },
+  ];
 
 const PROFILES_BY_HANDLE = new Map<string, CatalogPresentationProfile>(
   CATALOG_PRESENTATION_PROFILES.map((profile) => [profile.handle, profile]),
 );
 
-/** Returns the approved presentation profile, or `null` for unknown handles. */
 export function getCatalogPresentationProfile(
   handle: string,
 ): CatalogPresentationProfile | null {

--- a/src/lib/storefront/catalog-presentation.ts
+++ b/src/lib/storefront/catalog-presentation.ts
@@ -9,7 +9,6 @@ export interface PresentationColorway {
 
 export interface CatalogPresentationProfile {
   handle: string;
-  plate: string;
   category: ProductCategory;
   activities: readonly string[];
   subtitle: string;
@@ -40,7 +39,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
   [
     {
       handle: "weatherline-shell",
-      plate: "01",
       category: "shells",
       activities: ["alpine", "trail", "camp"],
       subtitle: "Three-layer waterproof shell for shifting coastal weather.",
@@ -54,7 +52,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "traverse-grid-fleece",
-      plate: "02",
       category: "shells",
       activities: ["trail", "alpine", "travel"],
       subtitle: "Breathable grid fleece for fast temperature changes.",
@@ -68,7 +65,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "drift-insulated-vest",
-      plate: "03",
       category: "shells",
       activities: ["alpine", "camp", "travel"],
       subtitle: "Packable synthetic warmth for exposed starts and stops.",
@@ -82,7 +78,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "ridge-30-field-pack",
-      plate: "04",
       category: "packs",
       activities: ["alpine", "trail"],
       subtitle: "A 30-liter pack built for long days above the treeline.",
@@ -96,7 +91,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "approach-18-day-pack",
-      plate: "05",
       category: "packs",
       activities: ["alpine", "trail", "travel"],
       subtitle: "Close-body 18-liter carry for short technical days.",
@@ -110,7 +104,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "waypoint-sling-6",
-      plate: "06",
       category: "packs",
       activities: ["travel", "camp"],
       subtitle: "Compact six-liter carry with fast, one-handed access.",
@@ -124,7 +117,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "talus-trail-shoe",
-      plate: "07",
       category: "footwear",
       activities: ["trail", "camp"],
       subtitle: "Grippy, stable footwear for scree, roots, and river rock.",
@@ -138,7 +130,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "scree-approach-shoe",
-      plate: "08",
       category: "footwear",
       activities: ["alpine", "trail"],
       subtitle: "Precise low-profile footwear for rock and mixed approaches.",
@@ -152,7 +143,6 @@ export const CATALOG_PRESENTATION_PROFILES: readonly CatalogPresentationProfile[
     },
     {
       handle: "camp-recovery-clog",
-      plate: "09",
       category: "footwear",
       activities: ["camp", "travel"],
       subtitle: "Easy-on recovery footwear with durable wet-ground traction.",

--- a/src/lib/storefront/collection-presentation.ts
+++ b/src/lib/storefront/collection-presentation.ts
@@ -30,8 +30,14 @@ export const COLLECTION_PRESENTATION_PROFILES = [
     },
     productHandles: [
       "weatherline-shell",
+      "traverse-grid-fleece",
+      "drift-insulated-vest",
       "ridge-30-field-pack",
+      "approach-18-day-pack",
+      "waypoint-sling-6",
       "talus-trail-shoe",
+      "scree-approach-shoe",
+      "camp-recovery-clog",
     ],
   },
   {
@@ -46,7 +52,11 @@ export const COLLECTION_PRESENTATION_PROFILES = [
       width: 1800,
       height: 1201,
     },
-    productHandles: ["weatherline-shell"],
+    productHandles: [
+      "weatherline-shell",
+      "traverse-grid-fleece",
+      "drift-insulated-vest",
+    ],
   },
   {
     handle: "packs",
@@ -60,7 +70,11 @@ export const COLLECTION_PRESENTATION_PROFILES = [
       width: 2000,
       height: 1334,
     },
-    productHandles: ["ridge-30-field-pack"],
+    productHandles: [
+      "ridge-30-field-pack",
+      "approach-18-day-pack",
+      "waypoint-sling-6",
+    ],
   },
   {
     handle: "footwear",
@@ -74,7 +88,11 @@ export const COLLECTION_PRESENTATION_PROFILES = [
       width: 2000,
       height: 1333,
     },
-    productHandles: ["talus-trail-shoe"],
+    productHandles: [
+      "talus-trail-shoe",
+      "scree-approach-shoe",
+      "camp-recovery-clog",
+    ],
   },
 ] as const satisfies readonly CollectionPresentationProfile[];
 

--- a/src/lib/storefront/collection-presentation.ts
+++ b/src/lib/storefront/collection-presentation.ts
@@ -1,3 +1,4 @@
+import { CANONICAL_PRODUCT_HANDLES } from "./catalog-presentation";
 import type { StorefrontImage } from "./types";
 
 export type CanonicalCollectionHandle =
@@ -28,17 +29,7 @@ export const COLLECTION_PRESENTATION_PROFILES = [
       width: 2000,
       height: 1333,
     },
-    productHandles: [
-      "weatherline-shell",
-      "traverse-grid-fleece",
-      "drift-insulated-vest",
-      "ridge-30-field-pack",
-      "approach-18-day-pack",
-      "waypoint-sling-6",
-      "talus-trail-shoe",
-      "scree-approach-shoe",
-      "camp-recovery-clog",
-    ],
+    productHandles: CANONICAL_PRODUCT_HANDLES,
   },
   {
     handle: "outerwear",

--- a/src/lib/storefront/content-presentation.ts
+++ b/src/lib/storefront/content-presentation.ts
@@ -41,6 +41,27 @@ export const ARTICLE_PRESENTATION_PROFILES = {
     coordinates: "57.0776° N, 3.6710° W",
     heroImage: EDITORIAL_IMAGES.campTent,
   },
+  "how-we-test-a-shell-before-calling-it-weatherproof": {
+    plate: "No. 04",
+    readingMinutes: 8,
+    location: "Lake District, England",
+    coordinates: "54.4609° N, 3.0886° W",
+    heroImage: EDITORIAL_IMAGES.campfire,
+  },
+  "a-two-day-kit-built-around-nine-kilograms": {
+    plate: "No. 05",
+    readingMinutes: 9,
+    location: "Snowdonia, Wales",
+    coordinates: "53.0685° N, 4.0763° W",
+    heroImage: EDITORIAL_IMAGES.trailMovement,
+  },
+  "repair-notes-what-five-years-of-use-should-look-like": {
+    plate: "No. 06",
+    readingMinutes: 8,
+    location: "Forward Repair Desk",
+    coordinates: "54.4609° N, 3.0886° W",
+    heroImage: EDITORIAL_IMAGES.alpineTraverse,
+  },
 } as const satisfies Record<string, ArticlePresentationProfile>;
 
 export const PAGE_PRESENTATION_PROFILES = {
@@ -63,6 +84,21 @@ export const PAGE_PRESENTATION_PROFILES = {
     eyebrow: "Contact",
     heroImage: EDITORIAL_IMAGES.trailMovement,
     sectionHeadings: [],
+  },
+  "materials-and-care": {
+    eyebrow: "Materials & Care",
+    heroImage: EDITORIAL_IMAGES.campfire,
+    sectionHeadings: ["Face fabrics and membranes", "Washing and reproofing"],
+  },
+  "fit-and-sizing": {
+    eyebrow: "Fit & Sizing",
+    heroImage: EDITORIAL_IMAGES.trailMovement,
+    sectionHeadings: ["Apparel fit", "Footwear sizing"],
+  },
+  "field-testing": {
+    eyebrow: "Field Testing",
+    heroImage: EDITORIAL_IMAGES.alpineTraverse,
+    sectionHeadings: ["What we test", "What ends a test"],
   },
 } as const satisfies Record<string, PagePresentationProfile>;
 

--- a/src/lib/storefront/fixtures/journal.ts
+++ b/src/lib/storefront/fixtures/journal.ts
@@ -1,139 +1,155 @@
-/**
- * Static journal fixture records. Only the data source may import this file.
- * `walking-the-long-light` is the approved route-smoke article handle.
- */
+/** Representative static Field Notes. Shopify owns the published long-form copy. */
 
 import type { JournalArticle } from "../types";
 import { EDITORIAL_IMAGES } from "./editorial-images";
 
 export const JOURNAL_FIXTURES: readonly JournalArticle[] = [
   {
-    handle: "walking-the-long-light",
-    title: "Walking the Long Light",
+    handle: "layering-for-moving-weather",
+    title: "Layering for Moving Weather",
     excerpt:
-      "Field notes from a week of low sun, long shadows, and unhurried miles.",
+      "How to layer for long climbs, fast descents, and uncertain forecasts.",
     plate: "No. 01",
-    publishedAt: "2026-07-18",
-    readingMinutes: 6,
-    location: "Cairngorms, Scotland",
-    coordinates: "57.0776° N, 3.6710° W",
+    publishedAt: "2026-07-24",
+    readingMinutes: 7,
+    location: "Pacific Crest Trail, California",
+    coordinates: "36.5785° N, 118.2923° W",
+    heroImage: EDITORIAL_IMAGES.mountainRidges,
+    body: [
+      {
+        type: "paragraph",
+        text: "Begin the climb slightly cool so the first hour does not soak the layers meant to protect the next six.",
+      },
+      { type: "heading", text: "Build around output" },
+      {
+        type: "paragraph",
+        text: "A breathable base, venting midlayer, and accessible shell create more range than one heavy garment.",
+      },
+      {
+        type: "pullquote",
+        text: "The best layer is the one adjusted before discomfort becomes a problem.",
+      },
+    ],
+  },
+  {
+    handle: "packing-thirty-liters-for-a-long-day",
+    title: "Packing Thirty Liters for a Long Day",
+    excerpt: "The honest pack list for a full mountain day.",
+    plate: "No. 02",
+    publishedAt: "2026-06-10",
+    readingMinutes: 5,
+    location: "North Cascades, Washington",
+    coordinates: "48.7718° N, 121.2985° W",
     heroImage: EDITORIAL_IMAGES.alpineTraverse,
     body: [
       {
         type: "paragraph",
-        text: "There is a month in the northern year when the sun never quite commits. It rises late, tracks low along the ridgeline, and spends the whole day looking like late afternoon. Photographers call it endless golden hour. Walkers call it a problem of arithmetic: eight hours of usable light, twenty miles of intention.",
+        text: "Thirty liters leaves margin for weather, food, water, repair, and the layer removed halfway up the first climb.",
       },
+      { type: "heading", text: "Pack the margin first" },
       {
         type: "paragraph",
-        text: "We planned the week around that arithmetic. Short approaches, long ridges, camps set before the color drained out of the west. The plan survived exactly one day, which is about average, and the week was better for it.",
-      },
-      { type: "heading", text: "The case for slow miles" },
-      {
-        type: "paragraph",
-        text: "Low light rearranges priorities. You stop optimizing for distance and start optimizing for attention — the frost pattern on a fence post, the way a burn cuts silver through black peat, the exact moment the shadow of one hill climbs the flank of the next. None of it counts as progress. All of it counts.",
-      },
-      {
-        type: "pullquote",
-        text: "You stop optimizing for distance and start optimizing for attention.",
-      },
-      {
-        type: "image",
-        image: EDITORIAL_IMAGES.campTent,
-        caption:
-          "Camp set early, for once. The rule of the week: stakes in before the color goes.",
-      },
-      { type: "heading", text: "What worked" },
-      {
-        type: "paragraph",
-        text: "Layers that vent without stopping. A pack that lets shoulders roll. Footwear that treats wet as a state of mind rather than an emergency. The kit list at the bottom of this note is short because the days demanded it — everything had to earn its place twice: once on the back, once in use.",
-      },
-      {
-        type: "note",
-        label: "Field note",
-        text: "Sunset at 15:41. Headlamps are not optional equipment in the long-light season; they are the second half of the day.",
-      },
-      {
-        type: "paragraph",
-        text: "By the last morning the arithmetic had inverted. We were no longer spending light to buy miles; we were spending miles to stay inside the light. That is the whole trick of the season, and probably of the sport.",
+        text: "Shelter, insulation, navigation, and repair tools establish the load before convenience items compete for space.",
       },
     ],
   },
   {
-    handle: "the-thirty-liter-rule",
-    title: "The Thirty-Liter Rule",
-    excerpt:
-      "Why the honest day pack is bigger than you think, and smaller than you fear.",
-    plate: "No. 02",
-    publishedAt: "2026-06-02",
-    readingMinutes: 4,
-    location: "Dolomites, Italy",
-    coordinates: "46.4102° N, 11.8440° E",
-    heroImage: EDITORIAL_IMAGES.trailMovement,
+    handle: "reading-the-trail-underfoot",
+    title: "Reading the Trail Underfoot",
+    excerpt: "Foot placement, pace, and terrain cues for moving efficiently.",
+    plate: "No. 03",
+    publishedAt: "2026-05-08",
+    readingMinutes: 6,
+    location: "Cairngorms, Scotland",
+    coordinates: "57.0776° N, 3.6710° W",
+    heroImage: EDITORIAL_IMAGES.campTent,
     body: [
       {
         type: "paragraph",
-        text: "Every gear closet contains the same argument, fought in liters. The twenty-liter pack that looks fast and carries nothing. The forty-five that swallows a weekend and rides like furniture. Somewhere between them is the honest number for a full mountain day, and after years of getting it wrong in both directions we keep arriving at thirty.",
+        text: "Texture changes before traction does. Loose stone, dark roots, and polished rock all announce themselves early.",
       },
-      { type: "heading", text: "The audit" },
+      { type: "heading", text: "Pace follows information" },
       {
         type: "paragraph",
-        text: "Run the audit on any long day: shell, insulation, two liters of water, food you actually want to eat, first aid, headlamp, and the margin — the space for a stripped layer, a wet fly, a friend's overflow. The margin is the part the twenty-liter pack pretends you will not need. The mountain disagrees, reliably, sometime after two in the afternoon.",
-      },
-      {
-        type: "pullquote",
-        text: "The margin is the part the small pack pretends you will not need.",
-      },
-      {
-        type: "paragraph",
-        text: "Thirty liters half-full carries better than twenty liters compressed to bursting. Fabric is lighter than regret. That is the whole rule, and it fits on an index card.",
-      },
-      {
-        type: "note",
-        label: "Field note",
-        text: "A pack that compresses well makes the rule work both ways — thirty liters cinched down is a day pack; opened up, it is shelter for everything the day produced.",
+        text: "Shorter steps preserve options when the ground becomes uncertain and reduce the corrections that consume energy.",
       },
     ],
   },
   {
-    handle: "a-defense-of-heavy-weather",
-    title: "A Defense of Heavy Weather",
+    handle: "how-we-test-a-shell-before-calling-it-weatherproof",
+    title: "How We Test a Shell Before Calling It Weatherproof",
     excerpt:
-      "The best days outside rarely happen under a blue sky. An argument for going anyway.",
-    plate: "No. 03",
-    publishedAt: "2026-04-14",
-    readingMinutes: 5,
-    location: "Lofoten, Norway",
-    coordinates: "68.1102° N, 13.6213° E",
+      "Hose tests, hill days, and the point where a seam decides everything.",
+    plate: "No. 04",
+    publishedAt: "2026-04-22",
+    readingMinutes: 8,
+    location: "Lake District, England",
+    coordinates: "54.4609° N, 3.0886° W",
     heroImage: EDITORIAL_IMAGES.campfire,
     body: [
       {
         type: "paragraph",
-        text: "The forecast said stay home. It usually does, in the places worth going. Forty knots on the tops, rain arriving sideways by noon, cloud down to the shoulder of the fjord. We went anyway — not out of bravado, but because the alternative was watching weather through glass, and weather through glass is just television.",
+        text: "A lab number starts the test; repeated wet hill days decide whether the pattern deserves the claim.",
       },
-      { type: "heading", text: "What the brochure leaves out" },
+      { type: "heading", text: "Start at the openings" },
       {
         type: "paragraph",
-        text: "Heavy weather edits a landscape honestly. It empties the trailheads, silences the drone pilots, and reduces the day to essentials: navigation you trust, layers that work, and the specific, unphotographable pleasure of being warm inside your hood while the world tears past outside it.",
-      },
-      {
-        type: "pullquote",
-        text: "Weather through glass is just television.",
-      },
-      {
-        type: "image",
-        image: EDITORIAL_IMAGES.campfire,
-        caption:
-          "The reward structure of heavy weather: fire, shelter, and the story already improving.",
-      },
-      {
-        type: "paragraph",
-        text: "There are rules. You do not defend heavy weather on exposed ridges, over water that can take you, or with people who did not sign up for it. The defense is of discomfort, not of danger — the two get confused only by people who have not spent enough time in either.",
+        text: "Cuffs, hood adjustment, pocket access, and seam intersections reveal practical weather resistance before the main fabric does.",
       },
       {
         type: "note",
         label: "Field note",
-        text: "Test days for gear are heavy days. A shell that works in April in Lofoten has told you everything it will ever need to say.",
+        text: "Testing continues after washing because a finish that works only when new is not a system.",
       },
     ],
   },
-] as const;
+  {
+    handle: "a-two-day-kit-built-around-nine-kilograms",
+    title: "A Two-Day Kit Built Around Nine Kilograms",
+    excerpt: "An overnight list with enough margin left for uncertain weather.",
+    plate: "No. 05",
+    publishedAt: "2026-03-19",
+    readingMinutes: 9,
+    location: "Snowdonia, Wales",
+    coordinates: "53.0685° N, 4.0763° W",
+    heroImage: EDITORIAL_IMAGES.trailMovement,
+    body: [
+      {
+        type: "paragraph",
+        text: "Nine kilograms is light enough to keep moving naturally and heavy enough to remain honest about shelter and weather.",
+      },
+      { type: "heading", text: "Count systems, not objects" },
+      {
+        type: "paragraph",
+        text: "Sleep, shelter, food, water, clothing, navigation, and repair each need a complete answer before individual items are optimized.",
+      },
+    ],
+  },
+  {
+    handle: "repair-notes-what-five-years-of-use-should-look-like",
+    title: "Repair Notes: What Five Years of Use Should Look Like",
+    excerpt:
+      "Wear patterns, honest failures, and repairs that keep gear in service.",
+    plate: "No. 06",
+    publishedAt: "2026-02-11",
+    readingMinutes: 8,
+    location: "Forward Repair Desk",
+    coordinates: "54.4609° N, 3.0886° W",
+    heroImage: EDITORIAL_IMAGES.alpineTraverse,
+    body: [
+      {
+        type: "paragraph",
+        text: "Five years of use leaves abrasion, softened edges, and local repairs. Those marks are evidence, not defects.",
+      },
+      { type: "heading", text: "Read the pattern of wear" },
+      {
+        type: "paragraph",
+        text: "Repeated stress at one seam may need reinforcement; even wear across a contact surface usually means the product is working as intended.",
+      },
+      {
+        type: "pullquote",
+        text: "Useful age is visible, specific, and repairable.",
+      },
+    ],
+  },
+];

--- a/src/lib/storefront/fixtures/pages.ts
+++ b/src/lib/storefront/fixtures/pages.ts
@@ -1,7 +1,4 @@
-/**
- * Static store-page fixture records. Only the data source may import this
- * file. `about-forward` is the approved route-smoke page handle.
- */
+/** Representative static pages for credential-free development. Shopify owns live copy. */
 
 import type { StorePage } from "../types";
 import { EDITORIAL_IMAGES } from "./editorial-images";
@@ -9,30 +6,23 @@ import { EDITORIAL_IMAGES } from "./editorial-images";
 export const PAGE_FIXTURES: readonly StorePage[] = [
   {
     handle: "about-forward",
-    title: "The Field Standard",
+    title: "About Forward",
     eyebrow: "About Forward",
     intro:
-      "Forward makes a short list of gear for moving through weather, not around it. Three products, built slowly, repaired indefinitely.",
+      "Forward makes a short list of equipment for moving through weather, not around it.",
     heroImage: EDITORIAL_IMAGES.mountainRidges,
     sections: [
       {
-        heading: "Why the list is short",
-        paragraphs: [
-          "Most gear companies solve problems by adding products. We solve them by revising the ones we already make. The catalog is three items long because that is how many things we currently believe we make better than anyone needs us to: a shell, a pack, and a trail shoe.",
-          "Each one is expected to hold a place in your kit for years. When a material or pattern improves, the product quietly improves with it — same name, same job, better execution.",
-        ],
-      },
-      {
         heading: "The standard",
         paragraphs: [
-          "Every Forward product is tested against the same three questions. Does it work when the weather turns? Does it carry its weight? Can we repair it when you finally wear it out?",
-          "If the answer to any of the three is no, it does not ship. This is also why we publish real specifications — weights, membranes, hydrostatic head — instead of adjectives.",
+          "Every object must carry well, work with the rest of the system, and remain useful after visible wear.",
+          "We revise existing patterns before adding new ones and design repair access into the construction from the start.",
         ],
       },
       {
-        heading: "Made to be repaired",
+        heading: "A short catalog",
         paragraphs: [
-          "A garment that cannot be repaired is a disposable with a long fuse. Buckles, straps, zips, laces, and insoles are stocked standard parts. Delaminations, tears, and blown seams route through the repairs program — see the Repairs page for how it works.",
+          "Nine products cover weather protection, insulation, carry, technical movement, and recovery without turning choice into noise.",
         ],
       },
     ],
@@ -40,14 +30,15 @@ export const PAGE_FIXTURES: readonly StorePage[] = [
   {
     handle: "field-repair",
     title: "Field Repair",
-    eyebrow: "Forward field service",
+    eyebrow: "Field Repair",
     intro: "Small damage should not end a trip or a product’s useful life.",
     heroImage: EDITORIAL_IMAGES.alpineTraverse,
     sections: [
       {
-        heading: "Stabilize, then repair",
+        heading: "A repairable standard",
         paragraphs: [
-          "Clean and dry the affected area, stabilize tears with a compatible repair patch, and contact Forward when a permanent repair or replacement component is needed.",
+          "Clean and dry the affected area before applying a compatible field patch. Record the damage and contact the repair desk when the trip is over.",
+          "Replaceable hardware, accessible seams, and honest material choices keep routine damage from becoming disposal.",
         ],
       },
     ],
@@ -55,15 +46,15 @@ export const PAGE_FIXTURES: readonly StorePage[] = [
   {
     handle: "shipping-returns",
     title: "Shipping & Returns",
-    eyebrow: "Forward service",
+    eyebrow: "Shipping & Returns",
     intro:
-      "Orders are prepared within two business days. Delivery estimates appear at checkout.",
+      "Delivery estimates appear at checkout and returns begin with a support request.",
     heroImage: EDITORIAL_IMAGES.campTent,
     sections: [
       {
-        heading: "Returns",
+        heading: "Before you send it back",
         paragraphs: [
-          "Unused items may be returned within 30 days in original condition. Contact support before returning worn footwear or equipment with field damage.",
+          "Keep packaging until fit and function are confirmed. Contact support before returning worn equipment so repair, exchange, and return routes stay clear.",
         ],
       },
     ],
@@ -71,39 +62,76 @@ export const PAGE_FIXTURES: readonly StorePage[] = [
   {
     handle: "contact",
     title: "Contact",
-    eyebrow: "Forward support",
+    eyebrow: "Contact",
     intro:
-      "Questions about fit, equipment, repairs, or an order can be sent through the contact form. Include your order number when applicable.",
+      "Use the store support path for product, fit, repair, shipping, return, and order questions.",
     heroImage: EDITORIAL_IMAGES.trailMovement,
     sections: [],
   },
   {
-    handle: "repairs",
-    title: "Repairs",
-    eyebrow: "Forward program",
+    handle: "materials-and-care",
+    title: "Materials & Care",
+    eyebrow: "Materials & Care",
     intro:
-      "Wearing something out is the point. When you do, we would rather fix it than replace it — for the life of the product, at honest cost.",
+      "Specific construction choices need equally specific care to keep working.",
+    heroImage: EDITORIAL_IMAGES.campfire,
     sections: [
       {
-        heading: "What we repair",
+        heading: "Face fabrics and membranes",
         paragraphs: [
-          "Shells: re-taping, delamination, zip and cord replacement, tears and burns. Packs: buckles, straps, stays, panel tears, seam failures. Footwear: outsole re-bonding within reason, plus standard replaceable parts like laces and insoles.",
-          "Crash damage, misadventure, and honest neglect are all repairable categories. We have seen worse than whatever you did.",
+          "Recycled nylon face fabrics balance abrasion resistance with packability. Waterproof products add a breathable membrane and taped seams.",
         ],
       },
       {
-        heading: "How it works",
+        heading: "Washing and reproofing",
         paragraphs: [
-          "Start a repair from your account or the address on the policy page, describe the damage, and ship the cleaned item to the workshop. Straightforward repairs turn around in about two weeks; structural work can take four.",
-          "Repairs that stem from a defect in materials or workmanship are always free. Everything else is quoted before we start, and the quote is the price.",
-        ],
-      },
-      {
-        heading: "Field kit",
-        paragraphs: [
-          "Every order ships with a small patch kit. Tenacious tape solves most trailside problems; press it on clean, dry fabric and it will outlast your opinion of it. Save the workshop for what the tape cannot hold.",
+          "Wash technical fabrics with dedicated cleaner, avoid softener, and use low heat only where the garment instructions allow it.",
         ],
       },
     ],
   },
-] as const;
+  {
+    handle: "fit-and-sizing",
+    title: "Fit & Sizing",
+    eyebrow: "Fit & Sizing",
+    intro:
+      "Choose size around the layers, load, and terrain the product is designed to handle.",
+    heroImage: EDITORIAL_IMAGES.trailMovement,
+    sections: [
+      {
+        heading: "Apparel fit",
+        paragraphs: [
+          "Shells clear a working midlayer while fleece and insulation stay closer to the body for efficient movement.",
+        ],
+      },
+      {
+        heading: "Footwear sizing",
+        paragraphs: [
+          "Forward footwear uses US sizing from 7 through 13. Confirm toe room with the socks used on the trail.",
+        ],
+      },
+    ],
+  },
+  {
+    handle: "field-testing",
+    title: "Field Testing",
+    eyebrow: "Field Testing",
+    intro:
+      "A product earns its place only after wet, loaded, cold, and repeat-use testing.",
+    heroImage: EDITORIAL_IMAGES.alpineTraverse,
+    sections: [
+      {
+        heading: "What we test",
+        paragraphs: [
+          "Movement, access, weather resistance, drying, repair access, and comfort are tested together rather than as isolated specifications.",
+        ],
+      },
+      {
+        heading: "What ends a test",
+        paragraphs: [
+          "A failure that cannot be repaired or explained sends the pattern back for revision instead of into the catalog.",
+        ],
+      },
+    ],
+  },
+];

--- a/src/lib/storefront/fixtures/products.ts
+++ b/src/lib/storefront/fixtures/products.ts
@@ -296,7 +296,6 @@ function buildProduct(profile: CatalogPresentationProfile): Product {
     handle: profile.handle,
     title: definition.title,
     subtitle: profile.subtitle,
-    plate: profile.plate,
     category: profile.category,
     activities: profile.activities,
     price,

--- a/src/lib/storefront/fixtures/products.ts
+++ b/src/lib/storefront/fixtures/products.ts
@@ -1,11 +1,9 @@
-/**
- * Static product fixture records for the Forward demo catalog.
- *
- * Only `src/lib/storefront/data-source.ts` may import this file. Images come
- * exclusively from the approved branded catalog mirrored in
- * `public/images/products/` (see `public/images/products/manifest.json`).
- */
+/** Static deterministic catalog used only when Shopify is not configured. */
 
+import {
+  CATALOG_PRESENTATION_PROFILES,
+  type CatalogPresentationProfile,
+} from "../catalog-presentation";
 import type {
   Money,
   Product,
@@ -27,12 +25,12 @@ function productImage(file: string, alt: string): StorefrontImage {
   };
 }
 
-function colorway(
+function fixtureColorway(
   id: string,
   name: string,
   swatchColor: string,
   filePrefix: string,
-  productTitle: string,
+  title: string,
 ): ProductColorway {
   return {
     id,
@@ -41,19 +39,19 @@ function colorway(
     images: {
       primary: productImage(
         `${filePrefix}-primary.webp`,
-        `${productTitle} in ${name} — studio view`,
+        `${title} in ${name} — primary view`,
       ),
       alternate: productImage(
         `${filePrefix}-alternate.webp`,
-        `${productTitle} in ${name} — alternate angle`,
+        `${title} in ${name} — alternate view`,
       ),
       detail: productImage(
         `${filePrefix}-detail.webp`,
-        `${productTitle} in ${name} — material detail`,
+        `${title} in ${name} — detail view`,
       ),
       context: productImage(
         `${filePrefix}-context.webp`,
-        `${productTitle} in ${name} — in the field`,
+        `${title} in ${name} — context view`,
       ),
     },
   };
@@ -65,192 +63,259 @@ function productVariants(
   options: readonly ProductOption[],
   price: Money,
 ): readonly ProductVariant[] {
-  const optionSelections =
-    options.length === 0
-      ? [[]]
-      : (options[0]?.values.map((value) => [
-          { name: options[0]?.name ?? "Option", value },
-        ]) ?? [[]]);
-
+  const values = options[0]?.values ?? [undefined];
   return colorwayIds.flatMap((colorwayId) =>
-    optionSelections.map((selectedOptions) => ({
-      id: `demo:${handle}:${colorwayId}:${
-        selectedOptions.map((option) => option.value).join(":") || "default"
-      }`,
-      colorwayId,
-      selectedOptions,
-      price,
-      availableForSale: true,
-    })),
+    values.map((value) => {
+      const selectedOptions =
+        value === undefined
+          ? []
+          : [{ name: options[0]?.name ?? "Option", value }];
+      return {
+        id: `demo:${handle}:${colorwayId}:${value ?? "default"}`,
+        colorwayId,
+        selectedOptions,
+        price,
+        availableForSale: true,
+      };
+    }),
   );
 }
 
-export const PRODUCT_FIXTURES: readonly Product[] = [
-  {
-    handle: "weatherline-shell",
+interface StaticProductDefinition {
+  title: string;
+  price: number;
+  description: string;
+  materials: string;
+  specs: readonly { label: string; value: string }[];
+  care: readonly string[];
+  optionValues?: readonly string[];
+  imagePrefixes: readonly string[];
+}
+
+const APPAREL_SIZES = ["XS", "S", "M", "L", "XL"] as const;
+const FOOTWEAR_SIZES = [
+  "US 7",
+  "US 8",
+  "US 9",
+  "US 10",
+  "US 11",
+  "US 12",
+  "US 13",
+] as const;
+
+const DEFINITIONS: Readonly<Record<string, StaticProductDefinition>> = {
+  "weatherline-shell": {
     title: "Weatherline Shell",
-    subtitle: "Three-layer waterproof shell for shifting coastal weather.",
-    plate: "01",
-    category: "shells",
-    activities: ["alpine", "trail", "camp"],
-    price: { amount: 248, currencyCode: "USD" },
+    price: 248,
     description:
-      "A three-layer hardshell cut for movement, not bulk. The Weatherline holds its own through sideways rain and ridge-top wind, then packs down small enough to forget until the sky turns.",
-    detailParagraphs: [
-      "The face fabric is a tightly woven 40-denier ripstop bonded to a breathable waterproof membrane and a soft tricot backer. Seams are fully taped; the main zip is water-resistant with an internal storm guard.",
-      "A single-pull helmet-compatible hood, two harness-clear hand pockets, and pit zips cover the essentials without adding trim you will never use. The hem drops slightly in back and cinches one-handed.",
-      "Cut for a mid layer underneath. If you are between sizes and ride the warm side, size down.",
-    ],
+      "A three-layer hardshell cut for movement, not bulk. Weather protection, useful venting, and a quiet articulated fit make it dependable through long days and fast changes.",
+    materials:
+      "A recycled 40-denier ripstop face, waterproof breathable membrane, soft tricot backer, fully taped seams, and a PFAS-free water-repellent finish.",
     specs: [
       { label: "Weight", value: "312 g (size M)" },
-      { label: "Fabric", value: "40D 3L ripstop, PFAS-free DWR" },
-      { label: "Waterproofing", value: "20,000 mm hydrostatic head" },
-      { label: "Breathability", value: "20,000 g/m²/24h" },
-      { label: "Packed size", value: "Stows into its own chest pocket" },
+      { label: "Waterproofing", value: "20,000 mm" },
       { label: "Fit", value: "Regular, mid-layer compatible" },
     ],
     care: [
-      "Machine wash cold on gentle with technical wash, zips closed.",
-      "Tumble dry low to reactivate the DWR finish.",
-      "Never use fabric softener or dry cleaning.",
+      "Machine wash cold with technical cleaner and zips closed.",
+      "Tumble dry low to reactivate the water-repellent finish.",
     ],
-    repair:
-      "Field-repair small punctures with tenacious tape; our repairs program handles delaminations, zip replacements, and re-taping for the life of the garment.",
-    colorways: [
-      colorway(
-        "charcoal",
-        "Charcoal",
-        "#3b403f",
-        "weatherline-charcoal",
-        "Weatherline Shell",
-      ),
-      colorway(
-        "claystone",
-        "Claystone",
-        "#a9705a",
-        "weatherline-claystone",
-        "Weatherline Shell",
-      ),
-    ],
-    options: [{ name: "Size", values: ["XS", "S", "M", "L", "XL"] }],
-    variants: productVariants(
-      "weatherline-shell",
-      ["charcoal", "claystone"],
-      [{ name: "Size", values: ["XS", "S", "M", "L", "XL"] }],
-      { amount: 248, currencyCode: "USD" },
-    ),
-    relatedHandles: ["ridge-30-field-pack", "talus-trail-shoe"],
+    optionValues: APPAREL_SIZES,
+    imagePrefixes: ["weatherline-charcoal", "weatherline-claystone"],
   },
-  {
-    handle: "ridge-30-field-pack",
-    title: "Ridge 30 Field Pack",
-    subtitle: "A 30-liter pack built for long days above the treeline.",
-    plate: "02",
-    category: "packs",
-    activities: ["alpine", "trail"],
-    price: { amount: 168, currencyCode: "USD" },
+  "traverse-grid-fleece": {
+    title: "Traverse Grid Fleece",
+    price: 148,
     description:
-      "Thirty liters is the honest size for a full day out: shell, food, water, a warm layer, and room left over for whatever the day produces. The Ridge carries close and quiet, with nothing swinging off the back.",
-    detailParagraphs: [
-      "The body is a 210-denier recycled nylon with a burlier 420-denier boot. A single top-loading chamber with an internal zip pocket keeps packing simple; a stretch front pocket swallows a wet shell without opening the bag.",
-      "The back panel uses a framesheet with a light aluminum stay — enough structure to transfer weight to the hipbelt without turning the pack into furniture. Side compression doubles as pole or axe carry.",
-      "Hipbelt pockets fit a phone or a day of snacks. The whole harness fits close enough to scramble in.",
+      "A breathable grid-fleece midlayer for high-output movement and quick temperature changes. It vents under load, dries quickly, and layers cleanly under a shell.",
+    materials:
+      "Recycled grid-fleece knit with a brushed interior, low-bulk cuffs, and reinforced pocket openings.",
+    specs: [
+      { label: "Weight", value: "320 g (size M)" },
+      { label: "Fit", value: "Trim active fit" },
+      { label: "Use", value: "Fast hiking and cold-weather layering" },
     ],
+    care: [
+      "Machine wash cold without fabric softener.",
+      "Tumble dry low or air dry.",
+    ],
+    optionValues: APPAREL_SIZES,
+    imagePrefixes: ["weatherline-charcoal", "weatherline-claystone"],
+  },
+  "drift-insulated-vest": {
+    title: "Drift Insulated Vest",
+    price: 188,
+    description:
+      "A packable synthetic-insulation layer for exposed starts, stops, and cold transitions. It adds core warmth without restricting movement.",
+    materials:
+      "Recycled ripstop shell with a water-repellent finish and mapped synthetic insulation.",
+    specs: [
+      { label: "Insulation", value: "60 g synthetic fill" },
+      { label: "Fit", value: "Regular layering fit" },
+      { label: "Packed size", value: "Stows into pocket" },
+    ],
+    care: [
+      "Machine wash cold with technical cleaner.",
+      "Tumble dry low to restore loft.",
+    ],
+    optionValues: APPAREL_SIZES,
+    imagePrefixes: ["weatherline-charcoal", "weatherline-claystone"],
+  },
+  "ridge-30-field-pack": {
+    title: "Ridge 30 Field Pack",
+    price: 198,
+    description:
+      "A stable 30-liter field pack for moving light without sacrificing access or durability. The close carry stays composed on rough ground.",
+    materials:
+      "High-tenacity recycled nylon body, reinforced base, aluminum stay, and weather-resistant hardware.",
     specs: [
       { label: "Volume", value: "30 L" },
       { label: "Weight", value: "980 g" },
-      { label: "Fabric", value: "210D recycled nylon, 420D boot" },
-      { label: "Back length", value: "One size, 43–53 cm torso" },
       { label: "Load range", value: "Comfortable to 12 kg" },
-      { label: "Hydration", value: "Internal sleeve, dual hose ports" },
     ],
     care: [
-      "Hose down and air-dry after gritty or salty trips.",
-      "Spot-clean with mild soap; never machine wash.",
-      "Store loosely packed, out of direct sun.",
+      "Hand wash with mild soap and cool water.",
+      "Air dry away from direct heat.",
     ],
-    repair:
-      "Buckles, straps, and stays are standard parts we stock for replacement. Torn panels and blown seams go through the repairs program rather than the landfill.",
-    colorways: [
-      colorway(
-        "charcoal",
-        "Charcoal",
-        "#3b403f",
-        "ridge-charcoal",
-        "Ridge 30 Field Pack",
-      ),
-      colorway("dune", "Dune", "#c4ad83", "ridge-dune", "Ridge 30 Field Pack"),
-    ],
-    options: [],
-    variants: productVariants("ridge-30-field-pack", ["charcoal", "dune"], [], {
-      amount: 168,
-      currencyCode: "USD",
-    }),
-    relatedHandles: ["weatherline-shell", "talus-trail-shoe"],
+    imagePrefixes: ["ridge-charcoal", "ridge-dune"],
   },
-  {
-    handle: "talus-trail-shoe",
-    title: "Talus Trail Shoe",
-    subtitle: "Grippy, stable footwear for scree, roots, and river rock.",
-    plate: "03",
-    category: "footwear",
-    activities: ["trail", "camp"],
-    price: { amount: 142, currencyCode: "USD" },
+  "approach-18-day-pack": {
+    title: "Approach 18 Day Pack",
+    price: 148,
     description:
-      "The Talus is built for the ground most trails are actually made of: loose rock, wet roots, and off-camber dirt. Sticky rubber and a stable midsole platform, without the dead weight of a boot.",
-    detailParagraphs: [
-      "The outsole uses 4.5 mm multidirectional lugs in a sticky compound that holds on wet rock and sheds mud instead of carrying it. A forefoot rock plate takes the sting out of sharp talus.",
-      "The midsole is firm enough to edge on but cushioned for full days under load. A wide-ish toe box lets feet spread on descents without swimming in the shoe.",
-      "The engineered mesh upper drains fast and dries on the move. No waterproof liner by design — wet feet that dry beat wet feet that stay wet.",
-    ],
+      "A close-body 18-liter pack for short technical days and fast access. It remains stable on scrambling terrain without excess structure.",
+    materials:
+      "High-tenacity recycled nylon, reinforced base, close-body harness, and weather-resistant zippers.",
     specs: [
-      { label: "Weight", value: "298 g (per shoe, EU 42)" },
+      { label: "Volume", value: "18 L" },
+      { label: "Carry", value: "Close-body panel" },
+      { label: "Use", value: "Approaches and short technical days" },
+    ],
+    care: ["Hand wash with mild soap.", "Air dry completely before storage."],
+    imagePrefixes: ["ridge-charcoal", "ridge-dune"],
+  },
+  "waypoint-sling-6": {
+    title: "Waypoint Sling 6",
+    price: 98,
+    description:
+      "A compact six-liter carry for travel, daily field essentials, and quick organization. The main compartment opens with one hand.",
+    materials:
+      "Recycled nylon body, padded back panel, adjustable strap, and weather-resistant main zipper.",
+    specs: [
+      { label: "Volume", value: "6 L" },
+      { label: "Carry", value: "Cross-body sling" },
+      { label: "Use", value: "Travel and daily field carry" },
+    ],
+    care: ["Spot clean with mild soap and cool water.", "Air dry completely."],
+    imagePrefixes: ["ridge-charcoal", "ridge-dune"],
+  },
+  "talus-trail-shoe": {
+    title: "Talus Trail Shoe",
+    price: 168,
+    description:
+      "A precise trail shoe tuned for mixed rock, loose dirt, and technical descents. It balances protection, confident edge control, and sustained-mileage cushioning.",
+    materials:
+      "Abrasion-resistant woven upper, protective overlays, responsive foam, and a high-traction rubber outsole.",
+    specs: [
+      { label: "Weight", value: "298 g (per shoe, US 9)" },
       { label: "Drop", value: "6 mm" },
-      { label: "Stack", value: "28 mm heel / 22 mm forefoot" },
-      { label: "Lugs", value: "4.5 mm multidirectional, sticky compound" },
-      { label: "Protection", value: "Forefoot rock plate, welded toe cap" },
-      { label: "Upper", value: "Quick-drain engineered mesh" },
+      { label: "Lugs", value: "4.5 mm multidirectional" },
     ],
     care: [
-      "Knock off dry mud and rinse with fresh water.",
-      "Air-dry with insoles out; never on a radiator.",
-      "Re-lace loosely for storage so the upper keeps its shape.",
+      "Brush off dirt and hand wash with cool water.",
+      "Air dry away from direct heat.",
     ],
-    repair:
-      "Delaminated outsoles within reason are re-bonded through the repairs program. Worn laces and insoles are standard replaceable parts.",
-    colorways: [
-      colorway(
-        "charcoal",
-        "Charcoal",
-        "#3b403f",
-        "talus-charcoal",
-        "Talus Trail Shoe",
-      ),
-      colorway(
-        "limestone",
-        "Limestone",
-        "#cfc8b8",
-        "talus-limestone",
-        "Talus Trail Shoe",
-      ),
-    ],
-    options: [
-      {
-        name: "Size (EU)",
-        values: ["39", "40", "41", "42", "43", "44", "45", "46"],
-      },
-    ],
-    variants: productVariants(
-      "talus-trail-shoe",
-      ["charcoal", "limestone"],
-      [
-        {
-          name: "Size (EU)",
-          values: ["39", "40", "41", "42", "43", "44", "45", "46"],
-        },
-      ],
-      { amount: 142, currencyCode: "USD" },
-    ),
-    relatedHandles: ["ridge-30-field-pack", "weatherline-shell"],
+    optionValues: FOOTWEAR_SIZES,
+    imagePrefixes: ["talus-charcoal", "talus-limestone"],
   },
-] as const;
+  "scree-approach-shoe": {
+    title: "Scree Approach Shoe",
+    price: 158,
+    description:
+      "A precise low-profile approach shoe for rock, mixed trail, and technical transitions. Sticky rubber and a protected forefoot keep footing deliberate.",
+    materials:
+      "Abrasion-resistant woven upper, protective toe cap, firm midsole, and sticky rubber outsole.",
+    specs: [
+      { label: "Drop", value: "8 mm" },
+      { label: "Platform", value: "Low-profile edging platform" },
+      { label: "Use", value: "Approaches and scrambling" },
+    ],
+    care: [
+      "Brush off dry dirt and hand wash.",
+      "Air dry away from direct heat.",
+    ],
+    optionValues: FOOTWEAR_SIZES,
+    imagePrefixes: ["talus-charcoal", "talus-limestone"],
+  },
+  "camp-recovery-clog": {
+    title: "Camp Recovery Clog",
+    price: 118,
+    description:
+      "Easy-on recovery and camp footwear with durable traction and weather-tolerant materials. It stays comfortable after long days and composed on wet ground.",
+    materials:
+      "Water-tolerant upper, molded foam midsole, adjustable heel strap, and durable rubber outsole.",
+    specs: [
+      { label: "Weight", value: "240 g (per shoe, US 9)" },
+      { label: "Closure", value: "Easy-on heel strap" },
+      { label: "Use", value: "Camp, travel, and recovery" },
+    ],
+    care: ["Rinse with cool water.", "Air dry; do not apply direct heat."],
+    optionValues: FOOTWEAR_SIZES,
+    imagePrefixes: ["talus-charcoal", "talus-limestone"],
+  },
+};
+
+function buildProduct(profile: CatalogPresentationProfile): Product {
+  const definition = DEFINITIONS[profile.handle];
+  if (definition === undefined) {
+    throw new Error(`Missing static product definition for ${profile.handle}.`);
+  }
+  const colorEntries = Object.entries(profile.colorways);
+  if (colorEntries.length !== definition.imagePrefixes.length) {
+    throw new Error(`Static colorway images do not match ${profile.handle}.`);
+  }
+  const colorways = colorEntries.map(([name, presentation], index) => {
+    const prefix = definition.imagePrefixes[index];
+    if (prefix === undefined) {
+      throw new Error(`Missing static image prefix for ${profile.handle}.`);
+    }
+    return fixtureColorway(
+      presentation.id,
+      name,
+      presentation.swatchColor,
+      prefix,
+      definition.title,
+    );
+  });
+  const options: readonly ProductOption[] =
+    definition.optionValues === undefined
+      ? []
+      : [{ name: "Size", values: definition.optionValues }];
+  const price: Money = { amount: definition.price, currencyCode: "USD" };
+  return {
+    handle: profile.handle,
+    title: definition.title,
+    subtitle: profile.subtitle,
+    plate: profile.plate,
+    category: profile.category,
+    activities: profile.activities,
+    price,
+    description: definition.description,
+    detailParagraphs: [definition.description, definition.materials],
+    specs: definition.specs,
+    care: definition.care,
+    repair: profile.repair,
+    colorways,
+    options,
+    variants: productVariants(
+      profile.handle,
+      colorways.map((entry) => entry.id),
+      options,
+      price,
+    ),
+    relatedHandles: profile.relatedHandles,
+  };
+}
+
+export const PRODUCT_FIXTURES: readonly Product[] =
+  CATALOG_PRESENTATION_PROFILES.map(buildProduct);

--- a/src/lib/storefront/product-state.ts
+++ b/src/lib/storefront/product-state.ts
@@ -88,9 +88,9 @@ export function resolveProductSelection(
   const requestIsComplete = product.options.every(
     (option) => requestedOptions[option.name] !== undefined,
   );
-  const exact = requestIsComplete
-    ? variants.find(matchesRequested)
-    : candidates.find(matchesRequested);
+  const exact = (requestIsComplete ? variants : candidates).find(
+    matchesRequested,
+  );
   const variant = exact ?? fallback;
   return {
     colorway,

--- a/src/lib/storefront/product-state.ts
+++ b/src/lib/storefront/product-state.ts
@@ -1,17 +1,36 @@
 /**
- * Pure helpers for colorway selection, gallery composition, and deep-link
- * URLs. Shared by PLP cards, the PDP, and unit tests so selection semantics
- * stay identical everywhere.
+ * Pure helpers for product selection, gallery composition, and deep-link URLs.
+ * Shared by PLP cards, PDP controls, cart integration, and unit tests so every
+ * option resolves to one exact purchasable variant.
  */
 
-import type { Product, ProductColorway, StorefrontImage } from "./types";
+import type {
+  Product,
+  ProductColorway,
+  ProductVariant,
+  StorefrontImage,
+} from "./types";
 
 export const COLORWAY_PARAM = "colorway";
 
+export interface ProductSelection {
+  colorway: ProductColorway;
+  selectedOptions: Readonly<Record<string, string>>;
+  variant: ProductVariant;
+}
+
+/** Stable URL key for a normalized non-Color product option. */
+export function optionParamKey(optionName: string): string {
+  return optionName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 /**
- * Resolves the active colorway for a product. Unknown or absent ids fall back
- * to the first (canonical) colorway so stale deep links keep rendering a real
- * product state.
+ * Resolves the active colorway. Unknown or absent ids fall back to the first
+ * canonical colorway so stale links continue to render a real product state.
  */
 export function resolveColorway(
   product: Product,
@@ -21,15 +40,78 @@ export function resolveColorway(
   if (fallback === undefined) {
     throw new Error(`product ${product.handle} has no colorways`);
   }
-  if (colorwayId === undefined) {
-    return fallback;
-  }
+  if (colorwayId === undefined) return fallback;
   return product.colorways.find((entry) => entry.id === colorwayId) ?? fallback;
 }
 
 /** True when the id names a real colorway of the product. */
 export function isKnownColorway(product: Product, colorwayId: string): boolean {
   return product.colorways.some((entry) => entry.id === colorwayId);
+}
+
+function variantOptionMap(
+  variant: ProductVariant,
+): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    variant.selectedOptions.map(({ name, value }) => [name, value]),
+  );
+}
+
+/**
+ * Resolves one complete selection. A complete requested variant is honored
+ * even when sold out so deep links remain truthful and ATC can be disabled.
+ * Missing or impossible state falls back to an available variant first.
+ */
+export function resolveProductSelection(
+  product: Product,
+  colorwayId: string | undefined,
+  requestedOptions: Readonly<Record<string, string | undefined>> = {},
+): ProductSelection {
+  const colorway = resolveColorway(product, colorwayId);
+  const variants = product.variants.filter(
+    (variant) => variant.colorwayId === colorway.id,
+  );
+  const available = variants.filter((variant) => variant.availableForSale);
+  const candidates = available.length > 0 ? available : variants;
+  const fallback = candidates[0];
+  if (fallback === undefined) {
+    throw new Error(`product ${product.handle} has no variants for colorway`);
+  }
+
+  const matchesRequested = (variant: ProductVariant) => {
+    const values = variantOptionMap(variant);
+    return product.options.every((option) => {
+      const requested = requestedOptions[option.name];
+      return requested === undefined || values[option.name] === requested;
+    });
+  };
+  const requestIsComplete = product.options.every(
+    (option) => requestedOptions[option.name] !== undefined,
+  );
+  const exact = requestIsComplete
+    ? variants.find(matchesRequested)
+    : candidates.find(matchesRequested);
+  const variant = exact ?? fallback;
+  return {
+    colorway,
+    selectedOptions: variantOptionMap(variant),
+    variant,
+  };
+}
+
+/** Finds the exact variant represented by a complete option state. */
+export function findExactVariant(
+  product: Product,
+  colorwayId: string,
+  selectedOptions: Readonly<Record<string, string>>,
+): ProductVariant | undefined {
+  return product.variants.find((variant) => {
+    if (variant.colorwayId !== colorwayId) return false;
+    const values = variantOptionMap(variant);
+    return product.options.every(
+      (option) => values[option.name] === selectedOptions[option.name],
+    );
+  });
 }
 
 /** The complete four-image PDP gallery for a colorway, in display order. */
@@ -45,18 +127,34 @@ export function galleryImages(
 }
 
 /**
- * Canonical deep link for a product colorway. The first colorway is the
- * canonical unparameterized URL so repeated navigation to the default state
- * never changes the address.
+ * Canonical product URL for one complete selection. Selection-owned params are
+ * replaced while unrelated query state (for example attribution) is retained.
  */
+export function productSelectionHref(
+  product: Product,
+  colorwayId: string,
+  selectedOptions: Readonly<Record<string, string>> = {},
+  currentParams?: URLSearchParams,
+): string {
+  const params = new URLSearchParams(currentParams?.toString());
+  params.set(COLORWAY_PARAM, colorwayId);
+  for (const option of product.options) {
+    const key = optionParamKey(option.name);
+    const value = selectedOptions[option.name];
+    if (value === undefined) params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return `/products/${product.handle}${query === "" ? "" : `?${query}`}`;
+}
+
+/** Backwards-compatible card helper; PDP state uses productSelectionHref. */
 export function productColorwayHref(
   product: Product,
   colorwayId: string,
 ): string {
   const base = `/products/${product.handle}`;
   const first = product.colorways[0];
-  if (first !== undefined && colorwayId === first.id) {
-    return base;
-  }
+  if (first !== undefined && colorwayId === first.id) return base;
   return `${base}?${COLORWAY_PARAM}=${encodeURIComponent(colorwayId)}`;
 }

--- a/src/lib/storefront/shopify/content-mapper.ts
+++ b/src/lib/storefront/shopify/content-mapper.ts
@@ -144,7 +144,15 @@ function readPageNodes(
   data: Record<string, unknown>,
 ): readonly Record<string, unknown>[] {
   return readRequiredHandleSet(
-    [data.aboutForward, data.fieldRepair, data.shippingReturns, data.contact],
+    [
+      data.aboutForward,
+      data.fieldRepair,
+      data.shippingReturns,
+      data.contact,
+      data.materialsAndCare,
+      data.fitAndSizing,
+      data.fieldTesting,
+    ],
     CONTENT_PAGE_HANDLES,
     "content pages",
     (node) => node,

--- a/src/lib/storefront/shopify/content-query.ts
+++ b/src/lib/storefront/shopify/content-query.ts
@@ -5,6 +5,9 @@ export const CONTENT_PAGE_HANDLES = [
   "field-repair",
   "shipping-returns",
   "contact",
+  "materials-and-care",
+  "fit-and-sizing",
+  "field-testing",
 ] as const;
 
 export const CONTENT_BLOG_HANDLE = "field-notes" as const;
@@ -13,6 +16,9 @@ export const CONTENT_ARTICLE_HANDLES = [
   "layering-for-moving-weather",
   "packing-thirty-liters-for-a-long-day",
   "reading-the-trail-underfoot",
+  "how-we-test-a-shell-before-calling-it-weatherproof",
+  "a-two-day-kit-built-around-nine-kilograms",
+  "repair-notes-what-five-years-of-use-should-look-like",
 ] as const;
 
 export const CONTENT_POLICY_HANDLES = [
@@ -48,6 +54,15 @@ export const CONTENT_QUERY = gql(`
       ${PAGE_FIELDS}
     }
     contact: page(handle: "contact") {
+      ${PAGE_FIELDS}
+    }
+    materialsAndCare: page(handle: "materials-and-care") {
+      ${PAGE_FIELDS}
+    }
+    fitAndSizing: page(handle: "fit-and-sizing") {
+      ${PAGE_FIELDS}
+    }
+    fieldTesting: page(handle: "field-testing") {
       ${PAGE_FIELDS}
     }
     blog(handle: $blogHandle) {

--- a/src/lib/storefront/shopify/mapper.ts
+++ b/src/lib/storefront/shopify/mapper.ts
@@ -800,7 +800,6 @@ function mapProduct(node: unknown, index: number): Product {
     handle,
     title,
     subtitle: profile.subtitle,
-    plate: profile.plate,
     category: profile.category,
     activities: profile.activities,
     price,

--- a/src/lib/storefront/types.ts
+++ b/src/lib/storefront/types.ts
@@ -65,8 +65,6 @@ export interface Product {
   handle: string;
   title: string;
   subtitle: string;
-  /** Field-plate number used by the editorial framing, e.g. "01". */
-  plate: string;
   category: ProductCategory;
   activities: readonly string[];
   price: Money;

--- a/tests/demo-cart-logic.test.ts
+++ b/tests/demo-cart-logic.test.ts
@@ -24,7 +24,6 @@ function makeLine(overrides: Partial<DemoCartLine> = {}): DemoCartLine {
     title: "Weatherline Shell",
     colorwayId: "charcoal",
     colorwayName: "Charcoal",
-    size: "M",
     selectedOptions: { Size: "M" },
     quantity: 1,
     unitPrice: { amount: 100, currencyCode: "USD" },
@@ -77,7 +76,6 @@ describe("addLine", () => {
       makeLine({
         key: lineKey("weatherline-shell", "variant-l"),
         variantId: "variant-l",
-        size: "L",
         selectedOptions: { Size: "L" },
       }),
     );
@@ -192,10 +190,11 @@ describe("sanitizeLines", () => {
     assert.equal(lines[0]?.quantity, MAX_LINE_QUANTITY);
   });
 
-  it("drops lines whose revived size no longer matches their key", () => {
+  it("keeps selected options as the only persisted option state", () => {
     const valid = makeLine();
-    const lines = sanitizeLines([{ ...valid, size: 42 }]);
-    assert.deepEqual(lines, []);
+    const lines = sanitizeLines([{ ...valid, size: "stale" }]);
+    assert.deepEqual(lines, [valid]);
+    assert.equal("size" in (lines[0] ?? {}), false);
   });
 
   it("keeps persisted cart lines backed by owned Shopify media", () => {
@@ -230,6 +229,7 @@ describe("sanitizeLines", () => {
         },
       },
       { ...valid, image: { ...valid.image, width: -1 } },
+      { ...valid, selectedOptions: { Size: 42 } },
     ];
     assert.deepEqual(sanitizeLines(invalid), []);
   });

--- a/tests/demo-cart-logic.test.ts
+++ b/tests/demo-cart-logic.test.ts
@@ -18,12 +18,14 @@ import {
 
 function makeLine(overrides: Partial<DemoCartLine> = {}): DemoCartLine {
   return {
-    key: lineKey("weatherline-shell", "charcoal", "M"),
+    key: lineKey("weatherline-shell", "variant-m"),
+    variantId: "variant-m",
     productHandle: "weatherline-shell",
     title: "Weatherline Shell",
     colorwayId: "charcoal",
     colorwayName: "Charcoal",
     size: "M",
+    selectedOptions: { Size: "M" },
     quantity: 1,
     unitPrice: { amount: 100, currencyCode: "USD" },
     image: {
@@ -38,10 +40,10 @@ function makeLine(overrides: Partial<DemoCartLine> = {}): DemoCartLine {
 }
 
 describe("lineKey", () => {
-  it("is stable per product + colorway + size", () => {
-    assert.equal(lineKey("a", "b", "M"), lineKey("a", "b", "M"));
-    assert.notEqual(lineKey("a", "b", "M"), lineKey("a", "b", "L"));
-    assert.notEqual(lineKey("a", "b"), lineKey("a", "c"));
+  it("is stable per product variant", () => {
+    assert.equal(lineKey("a", "variant-m"), lineKey("a", "variant-m"));
+    assert.notEqual(lineKey("a", "variant-m"), lineKey("a", "variant-l"));
+    assert.notEqual(lineKey("a", "variant-m"), lineKey("b", "variant-m"));
   });
 });
 
@@ -73,8 +75,10 @@ describe("addLine", () => {
     const lines = addLine(
       [makeLine()],
       makeLine({
-        key: lineKey("weatherline-shell", "charcoal", "L"),
+        key: lineKey("weatherline-shell", "variant-l"),
+        variantId: "variant-l",
         size: "L",
+        selectedOptions: { Size: "L" },
       }),
     );
     assert.equal(lines.length, 2);
@@ -93,7 +97,10 @@ describe("setLineQuantity", () => {
   });
 
   it("leaves other lines untouched", () => {
-    const other = makeLine({ key: lineKey("ridge-30", "dune") });
+    const other = makeLine({
+      key: lineKey("ridge-30", "ridge-variant"),
+      variantId: "ridge-variant",
+    });
     const lines = setLineQuantity([makeLine(), other], makeLine().key, 4);
     assert.equal(lines.length, 2);
     assert.equal(lines[1]?.quantity, 1);
@@ -102,7 +109,10 @@ describe("setLineQuantity", () => {
 
 describe("removeLine", () => {
   it("removes only the addressed line", () => {
-    const other = makeLine({ key: lineKey("ridge-30", "dune") });
+    const other = makeLine({
+      key: lineKey("ridge-30", "ridge-variant"),
+      variantId: "ridge-variant",
+    });
     const lines = removeLine([makeLine(), other], makeLine().key);
     assert.deepEqual(lines, [other]);
   });
@@ -113,7 +123,8 @@ describe("totals", () => {
     const lines = [
       makeLine({ quantity: 2, unitPrice: { amount: 40, currencyCode: "USD" } }),
       makeLine({
-        key: lineKey("ridge-30", "dune"),
+        key: lineKey("ridge-30", "ridge-variant"),
+        variantId: "ridge-variant",
         quantity: 1,
         unitPrice: { amount: 30, currencyCode: "USD" },
       }),
@@ -159,8 +170,13 @@ describe("sanitizeLines", () => {
       null,
       42,
       { key: "missing-everything" },
-      { ...valid, key: lineKey("ridge-30", "dune"), quantity: "2" },
-      { ...valid, key: lineKey("talus-trail", "limestone"), image: {} },
+      {
+        ...valid,
+        key: lineKey("ridge-30", "ridge-variant"),
+        variantId: "ridge-variant",
+        quantity: "2",
+      },
+      { ...valid, key: lineKey("talus-trail", "talus-variant"), image: {} },
     ]);
     assert.equal(lines.length, 1);
     assert.equal(lines[0]?.key, valid.key);

--- a/tests/fixtures/shopify-catalog-response.ts
+++ b/tests/fixtures/shopify-catalog-response.ts
@@ -2,10 +2,11 @@
  * Synthetic Storefront API catalog responses for adapter tests.
  *
  * These are hand-built GraphQL-shaped objects that mirror the live catalog's
- * *shape* — three approved products, `Color` plus `Size` options, four media
- * roles per colorway, and the five `forward` metafields. They are not captured
- * live responses: media IDs, CDN paths, and copy are synthetic, and there are
- * no headers, signed CDN parameters, or credentials anywhere in this file.
+ * *shape* — the exact nine approved products, `Color` plus `Size` options, four
+ * media roles per colorway, and the five `forward` metafields. They are not
+ * captured live responses: media IDs, CDN paths, and copy are synthetic, and
+ * there are no headers, signed CDN parameters, or credentials anywhere in this
+ * file.
  *
  * Media nodes are deliberately emitted in reverse of the metafield order so
  * tests prove that role resolution comes from `forward.colorway_media_map`
@@ -66,6 +67,60 @@ const PRODUCT_SPECS: readonly ProductSpec[] = [
     mediaIdBase: 1000,
   },
   {
+    handle: "traverse-grid-fleece",
+    title: "Traverse Grid Fleece",
+    productType: "Outerwear",
+    description:
+      "A breathable grid-fleece midlayer built for high-output movement and fast temperature changes.\nThe Traverse Grid Fleece vents under load, dries quickly, and layers cleanly beneath a shell.",
+    price: "148.0",
+    colorways: [
+      { label: "Moss / Charcoal", filePrefix: "traverse-moss" },
+      { label: "Claystone / Bone", filePrefix: "traverse-claystone" },
+    ],
+    sizes: ["XS", "S", "M", "L", "XL"],
+    highlights: [
+      "Breathable grid-fleece structure",
+      "Fast-drying high-output midlayer",
+      "Layers cleanly under a shell",
+    ],
+    materials:
+      "Recycled grid-fleece knit with a brushed interior face and low-bulk bonded cuffs.",
+    fieldSpecs: {
+      weight_g: 320,
+      fit: "trim active",
+      recommended_use: ["hiking", "fastpacking", "cold-weather layering"],
+    },
+    care: "Machine wash cold on a gentle cycle without fabric softener. Tumble dry low or air dry.",
+    mediaIdBase: 2000,
+  },
+  {
+    handle: "drift-insulated-vest",
+    title: "Drift Insulated Vest",
+    productType: "Outerwear",
+    description:
+      "A packable synthetic-insulation layer for exposed starts, stops, and cold transitions.\nThe Drift Insulated Vest adds core warmth without limiting arm movement, then compresses into a pack lid.",
+    price: "188.0",
+    colorways: [
+      { label: "Charcoal / Signal", filePrefix: "drift-charcoal" },
+      { label: "Dune / Moss", filePrefix: "drift-dune" },
+    ],
+    sizes: ["XS", "S", "M", "L", "XL"],
+    highlights: [
+      "Packable synthetic core warmth",
+      "Wind-resistant recycled shell fabric",
+      "Compresses into its own pocket",
+    ],
+    materials:
+      "Recycled ripstop shell with a water-repellent finish and mapped synthetic insulation.",
+    fieldSpecs: {
+      insulation_g: 60,
+      fit: "layering regular",
+      recommended_use: ["alpine starts", "camp warmth", "cold transitions"],
+    },
+    care: "Machine wash cold with a technical cleaner. Tumble dry low to restore loft.",
+    mediaIdBase: 3000,
+  },
+  {
     handle: "ridge-30-field-pack",
     title: "Ridge 30 Field Pack",
     productType: "Packs",
@@ -89,7 +144,59 @@ const PRODUCT_SPECS: readonly ProductSpec[] = [
       recommended_use: ["day hiking", "field work", "light overnights"],
     },
     care: "Hand wash with mild soap and cool water. Air dry completely away from direct heat.",
-    mediaIdBase: 2000,
+    mediaIdBase: 4000,
+  },
+  {
+    handle: "approach-18-day-pack",
+    title: "Approach 18 Day Pack",
+    productType: "Packs",
+    description:
+      "A close-body 18-liter pack for short technical days and fast access.\nThe Approach 18 stays stable on scrambling terrain and opens without coming off your back.",
+    price: "148.0",
+    colorways: [
+      { label: "Moss / Charcoal", filePrefix: "approach-moss" },
+      { label: "Claystone / Dune", filePrefix: "approach-claystone" },
+    ],
+    highlights: [
+      "18-liter close-body carry",
+      "Stable on technical ground",
+      "Fast side and top access",
+    ],
+    materials:
+      "High-tenacity recycled nylon body with a reinforced base and weather-resistant zippers.",
+    fieldSpecs: {
+      volume_liters: 18,
+      carry: "close-body panel",
+      recommended_use: ["approaches", "short technical days", "travel"],
+    },
+    care: "Hand wash with mild soap and cool water. Air dry away from direct heat.",
+    mediaIdBase: 5000,
+  },
+  {
+    handle: "waypoint-sling-6",
+    title: "Waypoint Sling 6",
+    productType: "Packs",
+    description:
+      "A compact 6-liter carry for travel, daily field essentials, and quick organization.\nThe Waypoint Sling 6 keeps documents, tools, and a light layer within reach of one hand.",
+    price: "98.0",
+    colorways: [
+      { label: "Charcoal / Signal", filePrefix: "waypoint-charcoal" },
+      { label: "Dune / Moss", filePrefix: "waypoint-dune" },
+    ],
+    highlights: [
+      "6-liter everyday carry",
+      "Quick cross-body access",
+      "Organized document and tool pockets",
+    ],
+    materials:
+      "Recycled nylon body with a padded back panel and a weather-resistant main zipper.",
+    fieldSpecs: {
+      volume_liters: 6,
+      carry: "cross-body sling",
+      recommended_use: ["travel", "daily carry", "field organization"],
+    },
+    care: "Spot clean with mild soap and cool water. Air dry completely.",
+    mediaIdBase: 6000,
   },
   {
     handle: "talus-trail-shoe",
@@ -116,7 +223,61 @@ const PRODUCT_SPECS: readonly ProductSpec[] = [
       recommended_use: ["trail running", "fast hiking"],
     },
     care: "Brush off dry dirt, hand wash with cool water, and air dry. Do not machine wash or expose to direct heat.",
-    mediaIdBase: 3000,
+    mediaIdBase: 7000,
+  },
+  {
+    handle: "scree-approach-shoe",
+    title: "Scree Approach Shoe",
+    productType: "Footwear",
+    description:
+      "A precise low-profile approach shoe for rock, mixed trail, and technical transitions.\nThe Scree edges confidently, protects the forefoot, and keeps ground feel close underfoot.",
+    price: "158.0",
+    colorways: [
+      { label: "Charcoal / Gum", filePrefix: "scree-charcoal" },
+      { label: "Limestone / Moss", filePrefix: "scree-limestone" },
+    ],
+    sizes: ["US 7", "US 8", "US 9", "US 10", "US 11", "US 12", "US 13"],
+    highlights: [
+      "Low-profile edging platform",
+      "Sticky rubber approach outsole",
+      "Protective abrasion-resistant upper",
+    ],
+    materials:
+      "Abrasion-resistant woven upper, protective toe cap, firm midsole, and sticky rubber outsole.",
+    fieldSpecs: {
+      drop_mm: 8,
+      terrain: ["rock", "mixed trail", "scree"],
+      recommended_use: ["approaches", "scrambling"],
+    },
+    care: "Brush off dry dirt and hand wash with cool water. Air dry away from direct heat.",
+    mediaIdBase: 8000,
+  },
+  {
+    handle: "camp-recovery-clog",
+    title: "Camp Recovery Clog",
+    productType: "Footwear",
+    description:
+      "Easy-on recovery and camp footwear with durable traction and weather-tolerant materials.\nThe Camp Recovery Clog stays warm underfoot and handles wet ground without complaint.",
+    price: "118.0",
+    colorways: [
+      { label: "Charcoal / Moss", filePrefix: "camp-charcoal" },
+      { label: "Dune / Claystone", filePrefix: "camp-dune" },
+    ],
+    sizes: ["US 7", "US 8", "US 9", "US 10", "US 11", "US 12", "US 13"],
+    highlights: [
+      "Easy-on recovery fit",
+      "Weather-tolerant durable materials",
+      "Grippy camp and transition outsole",
+    ],
+    materials:
+      "Molded foam midsole, water-tolerant upper, and a durable rubber outsole.",
+    fieldSpecs: {
+      weight_g: 240,
+      closure: "easy-on heel strap",
+      recommended_use: ["camp", "travel", "recovery"],
+    },
+    care: "Rinse with cool water and air dry. Do not machine wash or apply direct heat.",
+    mediaIdBase: 9000,
   },
 ];
 

--- a/tests/fixtures/shopify-content-response.ts
+++ b/tests/fixtures/shopify-content-response.ts
@@ -10,12 +10,18 @@ const PAGE_HANDLES = [
   "field-repair",
   "shipping-returns",
   "contact",
+  "materials-and-care",
+  "fit-and-sizing",
+  "field-testing",
 ] as const;
 
 const ARTICLE_HANDLES = [
   "layering-for-moving-weather",
   "packing-thirty-liters-for-a-long-day",
   "reading-the-trail-underfoot",
+  "how-we-test-a-shell-before-calling-it-weatherproof",
+  "a-two-day-kit-built-around-nine-kilograms",
+  "repair-notes-what-five-years-of-use-should-look-like",
 ] as const;
 
 const POLICY_HANDLES = [
@@ -62,6 +68,12 @@ export interface ContentResponse {
     shippingReturns: any;
     // biome-ignore lint/suspicious/noExplicitAny: synthetic GraphQL payload
     contact: any;
+    // biome-ignore lint/suspicious/noExplicitAny: synthetic GraphQL payload
+    materialsAndCare: any;
+    // biome-ignore lint/suspicious/noExplicitAny: synthetic GraphQL payload
+    fitAndSizing: any;
+    // biome-ignore lint/suspicious/noExplicitAny: synthetic GraphQL payload
+    fieldTesting: any;
     blog: {
       handle: string;
       articles: {
@@ -105,12 +117,51 @@ export function contentResponse(): ContentResponse {
     "Questions about fit, repairs, or an order can be sent to Forward support.",
     "<p>Questions about fit, repairs, or an order can be sent to Forward support.</p>",
   );
+  const materialsAndCare = page(
+    "materials-and-care",
+    "Materials & Care",
+    "What our fabrics are made of, and what keeps them working.",
+    [
+      "<p>What our fabrics are made of, and what keeps them working.</p>",
+      "<h2>Face fabrics and membranes</h2>",
+      "<p>Shell fabrics are woven from recycled nylon and bonded to a breathable waterproof membrane.</p>",
+      "<h2>Washing and reproofing</h2>",
+      "<p>Wash technical fabrics with a dedicated cleaner and restore the finish with low heat.</p>",
+    ].join(""),
+  );
+  const fitAndSizing = page(
+    "fit-and-sizing",
+    "Fit & Sizing",
+    "How Forward layers are cut, and how to choose between two sizes.",
+    [
+      "<p>How Forward layers are cut, and how to choose between two sizes.</p>",
+      "<h2>Apparel fit</h2>",
+      "<p>Shells are cut to clear a midlayer; fleece and insulation are cut trimmer for movement.</p>",
+      "<h2>Footwear sizing</h2>",
+      '<p>Footwear runs true to US sizing. Ask <a href="/pages/contact">Contact</a> before ordering two sizes.</p>',
+    ].join(""),
+  );
+  const fieldTesting = page(
+    "field-testing",
+    "Field Testing",
+    "How a product earns its place in a short catalog.",
+    [
+      "<p>How a product earns its place in a short catalog.</p>",
+      "<h2>What we test</h2>",
+      "<p>Every product is tested wet, loaded, and cold before it is offered for sale.</p>",
+      "<h2>What ends a test</h2>",
+      "<p>A failure that cannot be repaired in the field ends the test and sends the pattern back.</p>",
+    ].join(""),
+  );
   return {
     data: {
       aboutForward,
       fieldRepair,
       shippingReturns,
       contact,
+      materialsAndCare,
+      fitAndSizing,
+      fieldTesting,
       blog: {
         handle: "field-notes",
         articles: {
@@ -136,6 +187,27 @@ export function contentResponse(): ContentResponse {
               "Foot placement, pace, and terrain cues for moving efficiently.",
               "2026-05-08",
               "<p>Terrain speaks early if you look down often enough.</p><p>Small shifts in texture usually tell you more than the color of the trail.</p>",
+            ),
+            article(
+              "how-we-test-a-shell-before-calling-it-weatherproof",
+              "How We Test a Shell Before Calling It Weatherproof",
+              "Hose tests, hill days, and the point where a seam decides everything.",
+              "2026-04-22",
+              "<p>A shell is not weatherproof because a lab number says so.</p><p>We wear the same pattern through wet hill days until a seam or a cuff tells us the truth.</p>",
+            ),
+            article(
+              "a-two-day-kit-built-around-nine-kilograms",
+              "A Two-Day Kit Built Around Nine Kilograms",
+              "The overnight list that fits a thirty-liter pack without leaving margin behind.",
+              "2026-03-19",
+              "<p>Nine kilograms is the weight where an overnight still moves like a day.</p><p>Everything on the list earns its place twice: once on the back, once in use.</p>",
+            ),
+            article(
+              "repair-notes-what-five-years-of-use-should-look-like",
+              "Repair Notes: What Five Years of Use Should Look Like",
+              "Wear patterns, honest failures, and the repairs that keep gear in service.",
+              "2026-02-11",
+              "<p>Five years of honest use leaves marks worth reading.</p><p>Most of what comes through the workshop is wear, not failure, and wear is repairable.</p>",
             ),
           ],
         },

--- a/tests/fixtures/shopify-navigation-response.ts
+++ b/tests/fixtures/shopify-navigation-response.ts
@@ -194,8 +194,14 @@ export function navigationResponse(): NavigationResponse {
               pageInfo: { hasNextPage: false },
               nodes: [
                 { handle: "weatherline-shell" },
+                { handle: "traverse-grid-fleece" },
+                { handle: "drift-insulated-vest" },
                 { handle: "ridge-30-field-pack" },
+                { handle: "approach-18-day-pack" },
+                { handle: "waypoint-sling-6" },
                 { handle: "talus-trail-shoe" },
+                { handle: "scree-approach-shoe" },
+                { handle: "camp-recovery-clog" },
               ],
             },
           },
@@ -205,7 +211,11 @@ export function navigationResponse(): NavigationResponse {
             description: "Weather protection for exposed ground.",
             products: {
               pageInfo: { hasNextPage: false },
-              nodes: [{ handle: "weatherline-shell" }],
+              nodes: [
+                { handle: "weatherline-shell" },
+                { handle: "traverse-grid-fleece" },
+                { handle: "drift-insulated-vest" },
+              ],
             },
           },
           {
@@ -214,7 +224,11 @@ export function navigationResponse(): NavigationResponse {
             description: "Carry systems for long field days.",
             products: {
               pageInfo: { hasNextPage: false },
-              nodes: [{ handle: "ridge-30-field-pack" }],
+              nodes: [
+                { handle: "ridge-30-field-pack" },
+                { handle: "approach-18-day-pack" },
+                { handle: "waypoint-sling-6" },
+              ],
             },
           },
           {
@@ -223,7 +237,11 @@ export function navigationResponse(): NavigationResponse {
             description: "Trail footwear for changing terrain.",
             products: {
               pageInfo: { hasNextPage: false },
-              nodes: [{ handle: "talus-trail-shoe" }],
+              nodes: [
+                { handle: "talus-trail-shoe" },
+                { handle: "scree-approach-shoe" },
+                { handle: "camp-recovery-clog" },
+              ],
             },
           },
         ],

--- a/tests/premium-theme-contract.test.ts
+++ b/tests/premium-theme-contract.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const readSource = (path: string) => readFile(path, "utf8");
+
+describe("premium theme contract", () => {
+  it("binds the approved typography roles", async () => {
+    const [layout, styles] = await Promise.all([
+      readSource("src/app/layout.tsx"),
+      readSource("src/app/canonical-source.css"),
+    ]);
+
+    assert.match(layout, /IBM_Plex_Mono, Manrope, Space_Grotesk/);
+    assert.match(layout, /variable: "--font-space-grotesk"/);
+    assert.doesNotMatch(layout, /Literata|font-literata/);
+    assert.match(
+      styles,
+      /--display: var\(--font-space-grotesk\), "Helvetica Neue", sans-serif;/,
+    );
+    assert.match(
+      styles,
+      /--ui: var\(--font-manrope\), "Helvetica Neue", sans-serif;/,
+    );
+    assert.match(styles, /--meta: var\(--font-plex-mono\), monospace;/);
+    assert.match(
+      styles,
+      /\.eyebrow,[\s\S]*?\.meta,[\s\S]*?\.breadcrumbs,[\s\S]*?font-family: var\(--meta\);/,
+    );
+    assert.doesNotMatch(styles, /--mono:|font-family: var\(--mono\);/);
+  });
+
+  it("removes the global coordinate rail without weakening mobile inertness", async () => {
+    const [header, styles] = await Promise.all([
+      readSource("src/components/field-index-header.tsx"),
+      readSource("src/app/canonical-source.css"),
+    ]);
+
+    assert.doesNotMatch(header, /coordinate-spine/);
+    assert.doesNotMatch(styles, /\.coordinate-spine/);
+    assert.match(
+      header,
+      /\.skip-link, \.announcement, \.field-header, #main-content, footer/,
+    );
+    assert.match(header, /element\.inert = true/);
+  });
+
+  it("uses one ordinal-free 4:5 product card across uniform grids", async () => {
+    const [card, home, productDetail, collectionPage, styles] =
+      await Promise.all([
+        readSource("src/components/product-card.tsx"),
+        readSource("src/app/page.tsx"),
+        readSource("src/app/products/[productHandle]/product-detail.tsx"),
+        readSource("src/app/shop/[collectionHandle]/page.tsx"),
+        readSource("src/app/canonical-source.css"),
+      ]);
+
+    assert.doesNotMatch(
+      card,
+      /index\??:|product-number|cardIndex|product\.plate/,
+    );
+    assert.doesNotMatch(home, /index=\{/);
+    assert.doesNotMatch(productDetail, /product\.plate|Plate \{/);
+    assert.doesNotMatch(collectionPage, /product\.plate/);
+    assert.match(styles, /\.product-card img \{[\s\S]*?aspect-ratio: 4 \/ 5;/);
+    assert.match(
+      styles,
+      /\.product-runway \{\s*grid-template-columns: repeat\(3, minmax\(0, 1fr\)\);/,
+    );
+    assert.match(
+      styles,
+      /\.plp-grid \{\s*grid-template-columns: repeat\(3, minmax\(0, 1fr\)\);/,
+    );
+    assert.doesNotMatch(styles, /\.product-runway \.product-card:nth-child/);
+    assert.doesNotMatch(styles, /\.plp-grid \.product-card:nth-child/);
+  });
+
+  it("places desktop PDP details left and gallery right while keeping mobile linear", async () => {
+    const styles = await readSource("src/app/canonical-source.css");
+
+    assert.match(
+      styles,
+      /\.pdp \{[\s\S]*?grid-template-areas: "details gallery";/,
+    );
+    assert.match(styles, /\.gallery \{[\s\S]*?grid-area: gallery;/);
+    assert.match(styles, /\.product-panel \{[\s\S]*?grid-area: details;/);
+    assert.match(
+      styles,
+      /@media \(max-width: 820px\)[\s\S]*?\.pdp \{[\s\S]*?grid-template-areas: "gallery" "details";/,
+    );
+    assert.match(
+      styles,
+      /@media \(max-width: 820px\)[\s\S]*?\.gallery \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
+    );
+  });
+
+  it("overrides desktop hero geometry at the mobile cascade winner", async () => {
+    const styles = await readSource("src/app/canonical-source.css");
+
+    assert.match(
+      styles,
+      /@media \(max-width: 820px\)[\s\S]*?\.page-hero-inner \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
+    );
+    assert.match(
+      styles,
+      /@media \(max-width: 820px\)[\s\S]*?\.hero-advanced \.hero-sub \{[\s\S]*?max-width: 100%;[\s\S]*?overflow-wrap: anywhere;/,
+    );
+  });
+
+  it("links repair surfaces to the exact owned page handle", async () => {
+    const [productPage, accountPage] = await Promise.all([
+      readSource("src/app/products/[productHandle]/page.tsx"),
+      readSource("src/app/account/page.tsx"),
+    ]);
+
+    for (const source of [productPage, accountPage]) {
+      assert.match(source, /href="\/pages\/field-repair"/);
+      assert.doesNotMatch(source, /href="\/pages\/repairs"/);
+    }
+  });
+
+  it("keeps the expanded PLP outline and empty state current", async () => {
+    const shop = await readSource("src/app/shop/page.tsx");
+
+    assert.match(shop, /<h2 className="sr-only">Products<\/h2>/);
+    assert.match(shop, /full catalog is nine/);
+    assert.doesNotMatch(shop, /No matching plates|full catalog is three/);
+  });
+});

--- a/tests/premium-theme-contract.test.ts
+++ b/tests/premium-theme-contract.test.ts
@@ -62,13 +62,16 @@ describe("premium theme contract", () => {
     assert.match(styles, /\.product-card img \{[\s\S]*?aspect-ratio: 4 \/ 5;/);
     assert.match(
       styles,
-      /\.product-runway \{\s*grid-template-columns: repeat\(3, minmax\(0, 1fr\)\);/,
+      /\.home-featured-grid \{\s*grid-template-columns: repeat\(4, minmax\(0, 1fr\)\);/,
     );
     assert.match(
       styles,
       /\.plp-grid \{\s*grid-template-columns: repeat\(3, minmax\(0, 1fr\)\);/,
     );
-    assert.doesNotMatch(styles, /\.product-runway \.product-card:nth-child/);
+    assert.doesNotMatch(
+      styles,
+      /\.home-featured-grid \.product-card:nth-child/,
+    );
     assert.doesNotMatch(styles, /\.plp-grid \.product-card:nth-child/);
   });
 
@@ -110,7 +113,7 @@ describe("premium theme contract", () => {
     );
     assert.match(
       styles,
-      /@media \(max-width: 820px\)[\s\S]*?\.hero-advanced \.hero-sub \{[\s\S]*?max-width: 100%;[\s\S]*?overflow-wrap: anywhere;/,
+      /@media \(max-width: 820px\)[\s\S]*?\.commerce-hero,[\s\S]*?grid-template-columns: minmax\(0, 1fr\);[\s\S]*?\.commerce-hero-media \{[\s\S]*?min-height: 68svh;/,
     );
   });
 

--- a/tests/premium-theme-contract.test.ts
+++ b/tests/premium-theme-contract.test.ts
@@ -11,13 +11,10 @@ describe("premium theme contract", () => {
       readSource("src/app/canonical-source.css"),
     ]);
 
-    assert.match(layout, /IBM_Plex_Mono, Manrope, Space_Grotesk/);
-    assert.match(layout, /variable: "--font-space-grotesk"/);
+    assert.match(layout, /Archivo, IBM_Plex_Mono, Manrope/);
+    assert.match(layout, /variable: "--font-archivo"/);
     assert.doesNotMatch(layout, /Literata|font-literata/);
-    assert.match(
-      styles,
-      /--display: var\(--font-space-grotesk\), "Helvetica Neue", sans-serif;/,
-    );
+    assert.match(styles, /--display: var\(--font-archivo\), sans-serif;/);
     assert.match(
       styles,
       /--ui: var\(--font-manrope\), "Helvetica Neue", sans-serif;/,
@@ -76,7 +73,10 @@ describe("premium theme contract", () => {
   });
 
   it("places desktop PDP details left and gallery right while keeping mobile linear", async () => {
-    const styles = await readSource("src/app/canonical-source.css");
+    const [styles, detail] = await Promise.all([
+      readSource("src/app/canonical-source.css"),
+      readSource("src/app/products/[productHandle]/product-detail.tsx"),
+    ]);
 
     assert.match(
       styles,
@@ -92,6 +92,13 @@ describe("premium theme contract", () => {
       styles,
       /@media \(max-width: 820px\)[\s\S]*?\.gallery \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
     );
+    assert.match(styles, /\.gallery-button:nth-child\(n \+ 4\)/);
+    assert.match(detail, /dialog\.showModal\(\)/);
+    assert.match(
+      detail,
+      /document\.documentElement\.style\.overflow = "hidden"/,
+    );
+    assert.match(detail, /triggerRef\.current\?\.focus\(\)/);
   });
 
   it("overrides desktop hero geometry at the mobile cascade winner", async () => {
@@ -125,5 +132,18 @@ describe("premium theme contract", () => {
     assert.match(shop, /<h2 className="sr-only">Products<\/h2>/);
     assert.match(shop, /full catalog is nine/);
     assert.doesNotMatch(shop, /No matching plates|full catalog is three/);
+  });
+
+  it("keeps custom compositions separate from Shopify regular pages", async () => {
+    const [about, materials, testing, regularPage] = await Promise.all([
+      readSource("src/app/about/page.tsx"),
+      readSource("src/app/materials/page.tsx"),
+      readSource("src/app/field-testing/page.tsx"),
+      readSource("src/app/pages/[pageHandle]/page.tsx"),
+    ]);
+    assert.match(about, /custom-story-page/);
+    assert.match(materials, /material-page/);
+    assert.match(testing, /testing-page/);
+    assert.match(regularPage, /storefront\.getPage/);
   });
 });

--- a/tests/product-state.test.ts
+++ b/tests/product-state.test.ts
@@ -5,8 +5,11 @@ import {
   COLORWAY_PARAM,
   galleryImages,
   isKnownColorway,
+  optionParamKey,
   productColorwayHref,
+  productSelectionHref,
   resolveColorway,
+  resolveProductSelection,
 } from "../src/lib/storefront/product-state.ts";
 import type { Product } from "../src/lib/storefront/types.ts";
 
@@ -93,6 +96,76 @@ describe("productColorwayHref", () => {
     assert.equal(
       productColorwayHref(product, "a b/c"),
       `/products/${product.handle}?${COLORWAY_PARAM}=a%20b%2Fc`,
+    );
+  });
+});
+
+describe("resolveProductSelection", () => {
+  it("selects the first available complete variant by default", () => {
+    const product = firstProduct();
+    const selection = resolveProductSelection(product, undefined);
+    assert.equal(selection.colorway, product.colorways[0]);
+    assert.equal(selection.variant.availableForSale, true);
+    assert.deepEqual(selection.selectedOptions, { Size: "XS" });
+  });
+
+  it("restores an exact colorway and option selection", () => {
+    const product = firstProduct();
+    const second = product.colorways[1];
+    assert.ok(second !== undefined);
+    const selection = resolveProductSelection(product, second.id, {
+      Size: "L",
+    });
+    assert.equal(selection.colorway.id, second.id);
+    assert.equal(selection.selectedOptions.Size, "L");
+    assert.equal(selection.variant.colorwayId, second.id);
+  });
+
+  it("falls back to a valid complete variant for stale option values", () => {
+    const product = firstProduct();
+    const selection = resolveProductSelection(product, undefined, {
+      Size: "__missing__",
+    });
+    assert.equal(selection.selectedOptions.Size, "XS");
+  });
+
+  it("preserves an exact sold-out deep link instead of swapping variants", () => {
+    const product = firstProduct();
+    const soldOut = product.variants[1];
+    assert.ok(soldOut);
+    const unavailableProduct = {
+      ...product,
+      variants: product.variants.map((variant) =>
+        variant.id === soldOut.id
+          ? { ...variant, availableForSale: false }
+          : variant,
+      ),
+    };
+    const selectedOptions = Object.fromEntries(
+      soldOut.selectedOptions.map(({ name, value }) => [name, value]),
+    );
+    const selection = resolveProductSelection(
+      unavailableProduct,
+      soldOut.colorwayId,
+      selectedOptions,
+    );
+    assert.equal(selection.variant.id, soldOut.id);
+    assert.equal(selection.variant.availableForSale, false);
+  });
+});
+
+describe("productSelectionHref", () => {
+  it("serializes every selected option and retains unrelated params", () => {
+    const product = firstProduct();
+    assert.equal(optionParamKey("Waist Size"), "waist-size");
+    assert.equal(
+      productSelectionHref(
+        product,
+        "claystone",
+        { Size: "M" },
+        new URLSearchParams("utm_source=field"),
+      ),
+      `/products/${product.handle}?utm_source=field&colorway=claystone&size=M`,
     );
   });
 });

--- a/tests/route-contract.test.ts
+++ b/tests/route-contract.test.ts
@@ -11,6 +11,7 @@ import {
   ROUTE_CONTRACT,
   SMOKE_FIXTURES,
 } from "../src/lib/routes/route-contract.ts";
+import { JOURNAL_FIXTURES } from "../src/lib/storefront/fixtures/journal.ts";
 import {
   formatRouteSegment,
   safeDecodeRouteSegment,
@@ -167,6 +168,11 @@ describe("route contract shape", () => {
     const handle = productSmoke.smoke.path.replace("/products/", "");
     assert.ok(
       (SMOKE_FIXTURES.productHandles as readonly string[]).includes(handle),
+    );
+    assert.ok(
+      JOURNAL_FIXTURES.some(
+        (article) => article.handle === SMOKE_FIXTURES.articleHandle,
+      ),
     );
   });
 

--- a/tests/shopify-catalog-adapter.test.ts
+++ b/tests/shopify-catalog-adapter.test.ts
@@ -218,7 +218,7 @@ describe("Hydrogen catalog client seam", () => {
         { useNextCache: false },
       );
       const result = await execute();
-      assert.equal(mapCatalogResult(result).length, 3);
+      assert.equal(mapCatalogResult(result).length, 9);
       assert.equal(new URL(requestUrl).pathname, "/api/2026-04/graphql.json");
       assert.equal(
         requestHeaders.get("shopify-storefront-private-token"),
@@ -294,7 +294,7 @@ describe("Hydrogen catalog client seam", () => {
       await assert.rejects(execute, ShopifyCatalogError);
       const recovered = await execute();
       assert.equal(calls, 2);
-      assert.equal(mapCatalogResult(recovered).length, 3);
+      assert.equal(mapCatalogResult(recovered).length, 9);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -346,7 +346,7 @@ describe("Hydrogen catalog client seam", () => {
         { useNextCache: false },
       );
       await assert.rejects(execute, ShopifyCatalogError);
-      assert.equal(mapCatalogResult(await execute()).length, 3);
+      assert.equal(mapCatalogResult(await execute()).length, 9);
       assert.equal(calls, 2);
     } finally {
       globalThis.fetch = originalFetch;
@@ -359,9 +359,9 @@ describe("Hydrogen catalog client seam", () => {
 /* -------------------------------------------------------------------------- */
 
 describe("catalog mapping", () => {
-  it("maps the three-product fixture to the normalized contract", () => {
+  it("maps the nine-product fixture to the normalized contract", () => {
     const products = mapped();
-    assert.equal(products.length, 3);
+    assert.equal(products.length, 9);
 
     const shell = products[0];
     assert.ok(shell !== undefined);
@@ -373,7 +373,7 @@ describe("catalog mapping", () => {
     assert.deepEqual([...shell.activities], ["alpine", "trail", "camp"]);
     assert.deepEqual(
       [...shell.relatedHandles],
-      ["ridge-30-field-pack", "talus-trail-shoe"],
+      ["traverse-grid-fleece", "ridge-30-field-pack"],
     );
     assert.ok(shell.subtitle.length > 0);
     assert.ok(shell.repair.length > 0);
@@ -469,8 +469,14 @@ describe("catalog mapping", () => {
       products.map((product) => product.colorways.map((entry) => entry.id)),
       [
         ["charcoal", "claystone"],
+        ["moss-charcoal", "claystone-bone"],
+        ["charcoal-signal", "dune-moss"],
         ["charcoal", "dune"],
+        ["moss-charcoal", "claystone-dune"],
+        ["charcoal-signal", "dune-moss"],
         ["charcoal", "limestone"],
+        ["charcoal-gum", "limestone-moss"],
+        ["charcoal-moss", "dune-claystone"],
       ],
     );
     assert.deepEqual(
@@ -484,13 +490,21 @@ describe("catalog mapping", () => {
     assert.deepEqual(products[0]?.options, [
       { name: "Size", values: ["XS", "S", "M", "L", "XL"] },
     ]);
-    assert.deepEqual(products[1]?.options, []);
-    assert.deepEqual(products[2]?.options, [
+    assert.deepEqual(products[1]?.options, [
+      { name: "Size", values: ["XS", "S", "M", "L", "XL"] },
+    ]);
+    assert.deepEqual(products[2]?.options, products[1]?.options);
+    assert.deepEqual(products[3]?.options, []);
+    assert.deepEqual(products[4]?.options, []);
+    assert.deepEqual(products[5]?.options, []);
+    assert.deepEqual(products[6]?.options, [
       {
         name: "Size",
         values: ["US 7", "US 8", "US 9", "US 10", "US 11", "US 12", "US 13"],
       },
     ]);
+    assert.deepEqual(products[7]?.options, products[6]?.options);
+    assert.deepEqual(products[8]?.options, products[6]?.options);
   });
 
   it("resolves the four media roles from the metafield id order", () => {
@@ -966,13 +980,19 @@ describe("ShopifyCatalogDataSource", () => {
     const byColorway = await source.searchProducts("limestone");
     assert.deepEqual(
       byColorway.map((product) => product.handle),
-      ["talus-trail-shoe"],
+      ["talus-trail-shoe", "scree-approach-shoe"],
     );
 
     const byActivity = await source.searchProducts("camp");
     assert.deepEqual(
       byActivity.map((product) => product.handle),
-      ["weatherline-shell", "talus-trail-shoe"],
+      [
+        "weatherline-shell",
+        "drift-insulated-vest",
+        "waypoint-sling-6",
+        "talus-trail-shoe",
+        "camp-recovery-clog",
+      ],
     );
   });
 
@@ -982,29 +1002,46 @@ describe("ShopifyCatalogDataSource", () => {
       (await source.listProducts({ category: "packs" })).map(
         (product) => product.handle,
       ),
-      ["ridge-30-field-pack"],
+      ["ridge-30-field-pack", "approach-18-day-pack", "waypoint-sling-6"],
     );
     assert.deepEqual(
       (await source.listProducts({ activity: "alpine" })).map(
         (product) => product.handle,
       ),
-      ["weatherline-shell", "ridge-30-field-pack"],
+      [
+        "weatherline-shell",
+        "traverse-grid-fleece",
+        "drift-insulated-vest",
+        "ridge-30-field-pack",
+        "approach-18-day-pack",
+        "scree-approach-shoe",
+      ],
     );
     assert.deepEqual(
       (await source.listProducts({}, "price-asc")).map(
         (product) => product.price.amount,
       ),
-      [168, 198, 248],
+      [98, 118, 148, 148, 158, 168, 188, 198, 248],
     );
     assert.deepEqual(
       (await source.listProducts({}, "price-desc")).map(
         (product) => product.price.amount,
       ),
-      [248, 198, 168],
+      [248, 198, 188, 168, 158, 148, 148, 118, 98],
     );
     assert.deepEqual(
       (await source.listProducts({}, "name")).map((product) => product.title),
-      ["Ridge 30 Field Pack", "Talus Trail Shoe", "Weatherline Shell"],
+      [
+        "Approach 18 Day Pack",
+        "Camp Recovery Clog",
+        "Drift Insulated Vest",
+        "Ridge 30 Field Pack",
+        "Scree Approach Shoe",
+        "Talus Trail Shoe",
+        "Traverse Grid Fleece",
+        "Waypoint Sling 6",
+        "Weatherline Shell",
+      ],
     );
     assert.deepEqual(
       (await source.listProducts()).map((product) => product.handle),

--- a/tests/shopify-catalog-adapter.test.ts
+++ b/tests/shopify-catalog-adapter.test.ts
@@ -368,7 +368,6 @@ describe("catalog mapping", () => {
     assert.equal(shell.handle, "weatherline-shell");
     assert.equal(shell.title, "Weatherline Shell");
     assert.deepEqual(shell.price, { amount: 248, currencyCode: "USD" });
-    assert.equal(shell.plate, "01");
     assert.equal(shell.category, "shells");
     assert.deepEqual([...shell.activities], ["alpine", "trail", "camp"]);
     assert.deepEqual(
@@ -1266,7 +1265,6 @@ describe("catalog presentation profile", () => {
     for (const profile of CATALOG_PRESENTATION_PROFILES) {
       const product = byHandle.get(profile.handle);
       assert.ok(product !== undefined, `missing ${profile.handle}`);
-      assert.equal(product.plate, profile.plate);
       assert.equal(product.category, profile.category);
       assert.equal(product.subtitle, profile.subtitle);
       assert.equal(product.repair, profile.repair);

--- a/tests/shopify-content-adapter.test.ts
+++ b/tests/shopify-content-adapter.test.ts
@@ -59,11 +59,22 @@ describe("Shopify content mapper", () => {
         "layering-for-moving-weather",
         "packing-thirty-liters-for-a-long-day",
         "reading-the-trail-underfoot",
+        "how-we-test-a-shell-before-calling-it-weatherproof",
+        "a-two-day-kit-built-around-nine-kilograms",
+        "repair-notes-what-five-years-of-use-should-look-like",
       ],
     );
     assert.deepEqual(
       result.pages.map((page) => page.handle),
-      ["about-forward", "field-repair", "shipping-returns", "contact"],
+      [
+        "about-forward",
+        "field-repair",
+        "shipping-returns",
+        "contact",
+        "materials-and-care",
+        "fit-and-sizing",
+        "field-testing",
+      ],
     );
     assert.deepEqual(
       result.policies.map((policy) => policy.handle),
@@ -80,6 +91,14 @@ describe("Shopify content mapper", () => {
     assert.equal(result.pages[0]?.eyebrow, "About Forward");
     assert.equal(result.pages[0]?.sections[0]?.heading, "The standard");
     assert.equal(result.pages[3]?.sections.length, 0);
+    assert.equal(result.pages[4]?.eyebrow, "Materials & Care");
+    assert.equal(
+      result.pages[4]?.sections[0]?.heading,
+      "Face fabrics and membranes",
+    );
+    assert.equal(result.articles[3]?.plate, "No. 04");
+    assert.ok((result.articles[5]?.readingMinutes ?? 0) > 0);
+    assert.ok(result.articles[5]?.heroImage.src.startsWith("/images/"));
     assert.equal(result.policies[0]?.updatedAt, undefined);
     assert.equal(
       result.policies[0]?.sections
@@ -151,7 +170,7 @@ describe("Shopify content mapper", () => {
       contentResponseWith((response) => {
         response.data.blog?.articles.nodes.pop();
       }),
-      "reading-the-trail-underfoot",
+      "repair-notes-what-five-years-of-use-should-look-like",
     );
   });
 
@@ -213,9 +232,9 @@ describe("Shopify content data source", () => {
         source.getPolicy("shipping-policy"),
       ]);
 
-    assert.equal(articles.length, 3);
+    assert.equal(articles.length, 6);
     assert.equal(article?.title, "Layering for Moving Weather");
-    assert.equal(pages.length, 4);
+    assert.equal(pages.length, 7);
     assert.equal(page?.title, "About Forward");
     assert.equal(policies.length, 4);
     assert.equal(policy?.title, "Shipping Policy");
@@ -246,10 +265,10 @@ describe("Shopify content data source", () => {
 
     assert.ok(source instanceof StaticStorefrontDataSource);
     assert.equal(
-      (await source.getArticle("walking-the-long-light"))?.title,
-      "Walking the Long Light",
+      (await source.getArticle("layering-for-moving-weather"))?.title,
+      "Layering for Moving Weather",
     );
-    assert.equal((await source.getPage("repairs"))?.title, "Repairs");
+    assert.equal((await source.getPage("field-repair"))?.title, "Field Repair");
     assert.equal(
       (await source.getPolicy("shipping-policy"))?.updatedAt,
       "2026-07-01",

--- a/tests/shopify-navigation-adapter.test.ts
+++ b/tests/shopify-navigation-adapter.test.ts
@@ -212,13 +212,40 @@ describe("Shopify navigation mapping", () => {
           handle: "forward",
           productHandles: [
             "weatherline-shell",
+            "traverse-grid-fleece",
+            "drift-insulated-vest",
             "ridge-30-field-pack",
+            "approach-18-day-pack",
+            "waypoint-sling-6",
             "talus-trail-shoe",
+            "scree-approach-shoe",
+            "camp-recovery-clog",
           ],
         },
-        { handle: "outerwear", productHandles: ["weatherline-shell"] },
-        { handle: "packs", productHandles: ["ridge-30-field-pack"] },
-        { handle: "footwear", productHandles: ["talus-trail-shoe"] },
+        {
+          handle: "outerwear",
+          productHandles: [
+            "weatherline-shell",
+            "traverse-grid-fleece",
+            "drift-insulated-vest",
+          ],
+        },
+        {
+          handle: "packs",
+          productHandles: [
+            "ridge-30-field-pack",
+            "approach-18-day-pack",
+            "waypoint-sling-6",
+          ],
+        },
+        {
+          handle: "footwear",
+          productHandles: [
+            "talus-trail-shoe",
+            "scree-approach-shoe",
+            "camp-recovery-clog",
+          ],
+        },
       ],
     );
   });
@@ -429,7 +456,7 @@ describe("Shopify navigation data source", () => {
       (await source.getCollectionProducts("packs"))?.map(
         (product) => product.handle,
       ),
-      ["ridge-30-field-pack"],
+      ["ridge-30-field-pack", "approach-18-day-pack", "waypoint-sling-6"],
     );
   });
 
@@ -649,7 +676,7 @@ describe("Shopify navigation data source", () => {
       (await source.getCollectionProducts("outerwear"))?.map(
         (product) => product.handle,
       ),
-      ["weatherline-shell"],
+      ["weatherline-shell", "traverse-grid-fleece", "drift-insulated-vest"],
     );
     assert.equal(observed.length, 1);
   });

--- a/tests/storefront-data-source.test.ts
+++ b/tests/storefront-data-source.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import { CANONICAL_PRODUCT_HANDLES } from "../src/lib/storefront/catalog-presentation.ts";
 import { StaticStorefrontDataSource } from "../src/lib/storefront/data-source.ts";
+import {
+  CONTENT_ARTICLE_HANDLES,
+  CONTENT_PAGE_HANDLES,
+} from "../src/lib/storefront/shopify/content-query.ts";
 
 const storefront = new StaticStorefrontDataSource();
 
@@ -29,11 +34,40 @@ describe("StaticStorefrontDataSource unknown handles", () => {
 describe("StaticStorefrontDataSource known handles", () => {
   it("returns every fixture product by handle", async () => {
     const products = await storefront.listProducts();
-    assert.ok(products.length > 0);
+    assert.deepEqual(
+      products.map((product) => product.handle),
+      [...CANONICAL_PRODUCT_HANDLES],
+    );
     for (const product of products) {
       const found = await storefront.getProduct(product.handle);
       assert.equal(found?.handle, product.handle);
     }
+  });
+
+  it("keeps exact expanded product and content contracts", async () => {
+    const products = await storefront.listProducts();
+    const byHandle = new Map(
+      products.map((product) => [product.handle, product]),
+    );
+    assert.equal(byHandle.get("ridge-30-field-pack")?.price.amount, 198);
+    assert.equal(byHandle.get("talus-trail-shoe")?.price.amount, 168);
+    assert.deepEqual(byHandle.get("talus-trail-shoe")?.options[0]?.values, [
+      "US 7",
+      "US 8",
+      "US 9",
+      "US 10",
+      "US 11",
+      "US 12",
+      "US 13",
+    ]);
+    assert.deepEqual(
+      (await storefront.listPages()).map((page) => page.handle),
+      [...CONTENT_PAGE_HANDLES],
+    );
+    assert.deepEqual(
+      (await storefront.listArticles()).map((article) => article.handle),
+      [...CONTENT_ARTICLE_HANDLES],
+    );
   });
 
   it("returns only known products for a known collection", async () => {


### PR DESCRIPTION
## Summary

- expand the fail-closed storefront contract to 9 products, 4 collections, 7 pages, and 6 articles
- align deterministic fixtures, Shopify content mapping, presentation profiles, and adapter tests
- refine the premium theme typography, commerce grids, PDP composition, and responsive behavior
- align route smoke fixtures with the expanded exact content handles

## Verification

- `PUBLIC_STORE_DOMAIN=' ' PRIVATE_STOREFRONT_API_TOKEN=' ' bun run check`
- `PUBLIC_STORE_DOMAIN=' ' PRIVATE_STOREFRONT_API_TOKEN=' ' bun run smoke:routes`
- 293 tests passed
- 39 production pages generated
- 17 route patterns and 4 redirects verified
- 32 production route smoke checks passed
- responsive Home, PLP, and PDP QA at 390x844
- independent post-fix review approved with no blockers

## Follow-up

The remaining Home/PDP interaction and custom-page feedback will be handled as a separate follow-up after this baseline PR.

Refs #57